### PR TITLE
Removed X-Ray Id Generator

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -127,6 +127,11 @@ internal partial class Build : NukeBuild
 
             FileSystemTasks.CopyFileToDirectory(
                 RootDirectory / "src" / "AWS.Distro.OpenTelemetry.AutoInstrumentation" / "bin" / this.configuration /
+                "net8.0" / "OpenTelemetry.Extensions.AWS.dll",
+                this.openTelemetryDistributionFolder / "net");
+
+            FileSystemTasks.CopyFileToDirectory(
+                RootDirectory / "src" / "AWS.Distro.OpenTelemetry.AutoInstrumentation" / "bin" / this.configuration /
                 "net8.0" / "OpenTelemetry.ResourceDetectors.AWS.dll",
                 this.openTelemetryDistributionFolder / "net");
 

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <!-- TODO: Need to look into release those packages before GA -->
+    <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.4" />
     <PackageReference Include="OpenTelemetry.Sampler.AWS" Version="0.1.0-alpha.1" />

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -5,11 +5,14 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Extensions.AWS.Trace;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.ResourceDetectors.AWS;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using B3Propagator = OpenTelemetry.Extensions.Propagators.B3Propagator;
 
 namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
 
@@ -44,6 +47,20 @@ public class Plugin
     {
         if (this.IsApplicationSignalsEnabled())
         {
+            // setting the default propagators to be W3C tracecontext, b3, b3multi and xray
+            // Calling in the TracerProviderInitialized function to override whatever is set by
+            // the otel instrumentation. For Application Signals, these propagators are required.
+            // This is the function that sets the propagators in OTEL:
+            // https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/5d438056871e9eeaa483840693139491407c136f/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationSdkHelper.cs#L44
+            // and this is where where it's being called: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/5d438056871e9eeaa483840693139491407c136f/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs#L133
+            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+            [
+                new TraceContextPropagator(), // W3C tracecontext
+                new B3Propagator(singleHeader: true), // b3
+                new B3Propagator(singleHeader: false), // b3multi
+                new AWSXRayPropagator(), // xray
+            ]));
+
             tracerProvider.AddProcessor(AttributePropagatingSpanProcessorBuilder.Create().Build());
 
             string? intervalConfigString = System.Environment.GetEnvironmentVariable(MetricExportIntervalConfig);


### PR DESCRIPTION
*Description of changes:*
Removed X-Ray Id Generator as it's no longer needed. X-Ray now supports W3C so we don't need to convert traceId to X-Ray specific one. 

Adding the default propagators to be W3C tracecontext, b3, b3multi and xray. Calling in the TracerProviderInitialized function to override whatever is set by the otel instrumentation. For Application Signals, these propagators are required.
This is the function that sets the propagators in OTEL:
https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/5d438056871e9eeaa483840693139491407c136f/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationSdkHelper.cs#L44
and this is where where it's being called: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/5d438056871e9eeaa483840693139491407c136f/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs#L133

In [Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/912dd93ff19b7a4594bb9ed1a7d8cde4907a735d/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py#L62C55-L62C67) and [Java](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProvider.java#L29), we are overriding the ENV_VAR `OTEL_PROPAGATORS`. We are not doing the same with DotNet because we don't have mechanism to override the env var in the plugin and DotNet doesn't have [XRay in the list of supported propagators](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/5d438056871e9eeaa483840693139491407c136f/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationSdkHelper.cs#L44) yet. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

