### PR TITLE
Added logic to skip instrumentation for sampling API calls

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
@@ -18,6 +18,7 @@
     <!-- TODO: Need to look into release those packages before GA -->
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.4" />
     <PackageReference Include="OpenTelemetry.Sampler.AWS" Version="0.1.0-alpha.1" />

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -8,6 +8,7 @@ using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Extensions.AWS.Trace;
+using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.ResourceDetectors.AWS;
 using OpenTelemetry.Resources;
@@ -162,6 +163,23 @@ public class Plugin
         return builder;
     }
 
+    /// <summary>
+    /// To configure HttpOptions and skip instrumentation for certain APIs
+    /// </summary>
+    /// <param name="options"><see cref="HttpClientTraceInstrumentationOptions"/> options to configure</param>
+    public void ConfigureTracesOptions(HttpClientTraceInstrumentationOptions options)
+    {
+        options.FilterHttpRequestMessage = request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/GetSamplingRules" || request.RequestUri?.AbsolutePath == "/SamplingTargets")
+            {
+                return false;
+            }
+
+            return true;
+        };
+    }
+
     private bool IsApplicationSignalsEnabled()
     {
         return System.Environment.GetEnvironmentVariable(ApplicationSignalsEnabledConfig) == "true";
@@ -179,12 +197,9 @@ public class Plugin
     {
         var options = new OtlpExporterOptions();
 
-        Logger.Log(
-          LogLevel.Debug, "AWS Application Signals export protocol: %{0}", options.Protocol);
-
         string? applicationSignalsEndpoint = System.Environment.GetEnvironmentVariable(ApplicationSignalsExporterEndpointConfig);
-        string? protocolString = System.Environment.GetEnvironmentVariable(DefaultProtocolEnvVarName);
-        OtlpExportProtocol protocol = OtlpExportProtocol.HttpProtobuf;
+        string? protocolString = System.Environment.GetEnvironmentVariable(DefaultProtocolEnvVarName) ?? "http/protobuf";
+        OtlpExportProtocol protocol;
         if (protocolString == "http/protobuf")
         {
             applicationSignalsEndpoint = applicationSignalsEndpoint ?? "http://localhost:4316/v1/metrics";
@@ -197,11 +212,16 @@ public class Plugin
         }
         else
         {
-            throw new NotSupportedException("Unsupported AWS Application Signals export protocol: " + options.Protocol);
+            throw new NotSupportedException("Unsupported AWS Application Signals export protocol: " + protocolString);
         }
 
         options.Endpoint = new Uri(applicationSignalsEndpoint);
         options.Protocol = protocol;
+
+        Logger.Log(
+          LogLevel.Debug, "AWS Application Signals export protocol: %{0}", options.Protocol);
+        Logger.Log(
+          LogLevel.Debug, "AWS Application Signals export endpoint: %{0}", options.Endpoint);
 
         return new OtlpMetricExporter(options);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the Plugin to skip Sampling specific API calls such as `/GetSamplingRules` and `/SamplingTargets`. Before the change, the agent would be exporting traces for those APIs. After that change, they are no longer instrumented. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

