### PR TITLE
Fix metrics attribute test cases for AWS SDK based on OTEL Metrics Data Model Temporality

### DIFF
--- a/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/DynamoDBTests.cs
+++ b/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/DynamoDBTests.cs
@@ -48,11 +48,6 @@ public class DynamoDBTests(
 
     protected override Task CreateError(CancellationToken cancellationToken)
     {
-        return errorDdb.CreateTableAsync(new CreateTableRequest
-        {
-            TableName = "test_table", AttributeDefinitions = [new AttributeDefinition { AttributeName = "Id", AttributeType = ScalarAttributeType.S }],
-            KeySchema = [new KeySchemaElement { AttributeName = "Id", KeyType = KeyType.HASH }],
-            BillingMode = BillingMode.PAY_PER_REQUEST
-        }, cancellationToken);
+        return errorDdb.DeleteTableAsync(new DeleteTableRequest { TableName = "test_table_error" });
     }
 }

--- a/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/S3Tests.cs
+++ b/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/S3Tests.cs
@@ -36,6 +36,6 @@ public class S3Tests(
 
     protected override Task CreateError(CancellationToken cancellationToken)
     {
-        return errorClient.PutBucketAsync(new PutBucketRequest { BucketName = "valid-bucket-name" }, cancellationToken);
+        return errorClient.DeleteBucketAsync(new DeleteBucketRequest { BucketName = "test-bucket-error" });
     }
 }

--- a/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/SQSTests.cs
+++ b/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/SQSTests.cs
@@ -37,6 +37,6 @@ public class SQSTests(
 
     protected override Task CreateError(CancellationToken cancellationToken)
     {
-        return errorSqs.CreateQueueAsync(new CreateQueueRequest { QueueName = "test_queue" }, cancellationToken);
+        return errorSqs.DeleteQueueAsync(new DeleteQueueRequest { QueueUrl = "http://sqs.us-east-1.localstack:4566/000000000000/test_queue_error" });
     }
 }

--- a/test/contract-tests/tests/test/amazon/base/contract_test_base.py
+++ b/test/contract-tests/tests/test/amazon/base/contract_test_base.py
@@ -146,7 +146,7 @@ class ContractTestBase(TestCase):
         metrics: List[ResourceScopeMetric] = self.mock_collector_client.get_metrics(
             {LATENCY_METRIC, ERROR_METRIC, FAULT_METRIC}
         )
-        self._assert_metric_attributes(metrics, LATENCY_METRIC, 5000, **kwargs)
+        self._assert_metric_attributes(metrics, LATENCY_METRIC, 10000, **kwargs)
         self._assert_metric_attributes(metrics, ERROR_METRIC, expected_error, **kwargs)
         self._assert_metric_attributes(metrics, FAULT_METRIC, expected_fault, **kwargs)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix metrics attribute test cases for AWS SDK based on [OTEL Metrics Data Model Temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

