### PR TITLE
Fix remote resource value handling with special chars

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
@@ -406,9 +406,7 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
             else if (IsKeyPresent(span, AttributeAWSSQSQueueUrl))
             {
                 remoteResourceType = NormalizedSQSServiceName + "::Queue";
-                remoteResourceIdentifier = EscapeDelimiters(
-                    GetQueueName((string?)span.GetTagItem(AttributeAWSSQSQueueUrl))
-                );
+                remoteResourceIdentifier = EscapeDelimiters(GetQueueName((string?)span.GetTagItem(AttributeAWSSQSQueueUrl)));
             }
         }
         else if (IsDBSpan(span))

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
@@ -386,27 +386,29 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
             if (IsKeyPresent(span, AttributeAWSDynamoTableName))
             {
                 remoteResourceType = NormalizedDynamoDBServiceName + "::Table";
-                remoteResourceIdentifier = (string?)span.GetTagItem(AttributeAWSDynamoTableName);
+                remoteResourceIdentifier = EscapeDelimiters((string?)span.GetTagItem(AttributeAWSDynamoTableName));
             }
             else if (IsKeyPresent(span, AttributeAWSKinesisStreamName))
             {
                 remoteResourceType = NormalizedKinesisServiceName + "::Stream";
-                remoteResourceIdentifier = (string?)span.GetTagItem(AttributeAWSKinesisStreamName);
+                remoteResourceIdentifier = EscapeDelimiters((string?)span.GetTagItem(AttributeAWSKinesisStreamName));
             }
             else if (IsKeyPresent(span, AttributeAWSS3Bucket))
             {
                 remoteResourceType = NormalizedS3ServiceName + "::Bucket";
-                remoteResourceIdentifier = (string?)span.GetTagItem(AttributeAWSS3Bucket);
+                remoteResourceIdentifier = EscapeDelimiters((string?)span.GetTagItem(AttributeAWSS3Bucket));
             }
             else if (IsKeyPresent(span, AttributeAWSSQSQueueName))
             {
                 remoteResourceType = NormalizedSQSServiceName + "::Queue";
-                remoteResourceIdentifier = (string?)span.GetTagItem(AttributeAWSSQSQueueName);
+                remoteResourceIdentifier = EscapeDelimiters((string?)span.GetTagItem(AttributeAWSSQSQueueName));
             }
             else if (IsKeyPresent(span, AttributeAWSSQSQueueUrl))
             {
                 remoteResourceType = NormalizedSQSServiceName + "::Queue";
-                remoteResourceIdentifier = GetQueueName((string?)span.GetTagItem(AttributeAWSSQSQueueUrl));
+                remoteResourceIdentifier = EscapeDelimiters(
+                    GetQueueName((string?)span.GetTagItem(AttributeAWSSQSQueueUrl))
+                );
             }
         }
         else if (IsDBSpan(span))

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsMetricAttributesGeneratorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsMetricAttributesGeneratorTest.cs
@@ -839,6 +839,19 @@ public class AwsMetricAttributesGeneratorTest
             { AttributeAWSDynamoTableName, "aws_table_name" },
         };
         this.ValidateRemoteResourceAttributes(attributesCombination, "AWS::DynamoDB::Table", "aws_table_name");
+
+        // validate behavior of AttributeAWSDynamoTableName with special chars('|', '^')
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeAWSDynamoTableName, "aws_table|name" },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "AWS::DynamoDB::Table", "aws_table^|name");
+
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeAWSDynamoTableName, "aws_table^name" },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "AWS::DynamoDB::Table", "aws_table^^name");
     }
 
     private void ValidateRemoteResourceAttributes(Dictionary<string, object> attributesCombination, string type, string identifier, bool isAwsServiceTest = true)


### PR DESCRIPTION
*Description of changes:* Call `EscapeDelimiters()` on remote resource identifiers to ensure special characters are properly escaped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

