### PR TITLE
Added logic to build and release arm64 images

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Upload Artifact on MUSL arm64 Linux
         uses: actions/upload-artifact@v3
         with:
-          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
 
   dotnet-e2e-ec2-default-test:

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -81,6 +81,49 @@ jobs:
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-x64-musl
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
+  
+  build-arm64:
+    runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build on Linux
+        run: bash build.sh
+
+      - name: Test on Linux
+        run: dotnet test
+
+      - name: Upload Artifact on arm64 Linux
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+          path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+
+  build-arm64-musl:
+    runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+        with:
+          fetch-depth: 0
+
+      - name: Build in Docker container
+        run: |
+          set -e
+          docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
+          docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
+            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
+
+      - name: Upload Artifact on MUSL arm64 Linux
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64
+          path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
 
   dotnet-e2e-ec2-default-test:
     needs: [build]

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -44,6 +44,12 @@ jobs:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: ./artifacts/linux/x64
 
+      - name: Download Linux arm64 Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+          path: ./artifacts/linux/arm64
+
       - name: Download Windows Artifact
         uses: actions/download-artifact@v3
         with:
@@ -55,6 +61,12 @@ jobs:
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-x64-musl
           path: ./artifacts/linux/x64-musl
+      
+      - name: Download Linux arm64 MUSL Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-arm64-musl
+          path: ./artifacts/linux/arm64-musl
 
       - name: Configure AWS credentials for Private S3 Bucket
         uses: aws-actions/configure-aws-credentials@v4
@@ -123,11 +135,27 @@ jobs:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-x64-musl
           path: ./artifacts/linux/x64-musl
 
+      - name: Download Linux arm64 Artifact
+        if: runner.os == 'Linux'
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+          path: ./artifacts/linux/arm64
+
+      - name: Download Linux arm64 MUSL Artifact
+        if: runner.os == 'Linux'
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-arm64-musl
+          path: ./artifacts/linux/arm64-musl
+
       - name: Unzip Linux Artifact
         if: runner.os == 'Linux'
         run: |
           unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution
           unzip ./artifacts/linux/x64-musl/*.zip "linux-musl-x64/*" -d ./OpenTelemetryDistribution
+          unzip ./artifacts/linux/arm64/*.zip -d ./arm64/OpenTelemetryDistribution
+          unzip ./artifacts/linux/arm64-musl/*.zip "linux-musl-arm64/*" -d ./arm64/OpenTelemetryDistribution
 
       - name: Download Windows Artifact
         if: runner.os == 'Windows'
@@ -181,6 +209,16 @@ jobs:
           docker tag ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64
           docker push ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64
 
+      - name: Build Linux arm64 container
+        if: runner.os == 'Linux'
+        run: |
+          set -e
+          cd ./arm64
+          docker build --platform linux/arm64 -t ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-arm64 -f ../Dockerfile.linux .
+          docker push ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-arm64
+          docker tag ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-arm64 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-arm64
+          docker push ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-arm64
+
       - name: Build Windows container
         if: runner.os == 'Windows'
         run: |
@@ -231,12 +269,12 @@ jobs:
 
       - name: Create multi-platform image and push to Amazon private ECR
         run: |
-          docker manifest create ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }} ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64 ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2019 ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
+          docker manifest create ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }} ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64 ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-arm64 ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2019 ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
           docker manifest inspect ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
           docker manifest push ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
       - name: Create multi-platform image and push to Amazon public ECR
         run: |
-          docker manifest create ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }} ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2019 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
+          docker manifest create ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }} ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-amd64 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-arm46 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2019 ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
           docker manifest inspect ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
           docker manifest push ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Download Linux arm64 MUSL Artifact
         uses: actions/download-artifact@v3
         with:
-          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-arm64-musl
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: ./artifacts/linux/arm64-musl
 
       - name: Configure AWS credentials for Private S3 Bucket
@@ -146,7 +146,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/download-artifact@v3
         with:
-          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-arm64-musl
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: ./artifacts/linux/arm64-musl
 
       - name: Unzip Linux Artifact
@@ -154,6 +154,7 @@ jobs:
         run: |
           unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution
           unzip ./artifacts/linux/x64-musl/*.zip "linux-musl-x64/*" -d ./OpenTelemetryDistribution
+          mkdir ./arm64
           unzip ./artifacts/linux/arm64/*.zip -d ./arm64/OpenTelemetryDistribution
           unzip ./artifacts/linux/arm64-musl/*.zip "linux-musl-arm64/*" -d ./arm64/OpenTelemetryDistribution
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Verified that no additional code changes are required to support arm64 builds. Verified on an arm64 EC2 instance using both the zip file and the NuGet pkg. For NuGet, built it using an x64 mac and then used on an arm64 EC2 instance to verify that NuGet pkg is platform agnostic. 

For the release workflow testing: Tested using a local branch by moving the new release code to the main build and running it against a private ECR repo. The workflow passed and was able to push to private repo.

Pulled the image and verified that it’s an
```
"Architecture": "arm64",
"Os": "linux",
```
using docker image inspect and started a shell using the image and verified the instrumentation folder is there
```
user@88665a24d661 Downloads % docker run -it sha256:51ba09e404b9cdf7df7528bc9e28455b200021dfdc8db1f7a2efe01a735de704 sh   
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
sh-5.2# ls
autoinstrumentation  bin  boot	dev  etc  home	lib  lib64  local  media  mnt  opt  proc  root	run  sbin  srv	sys  tmp  usr  var
sh-5.2# cd autoinstrumentation/
sh-5.2# ls
AdditionalDeps	LICENSE  instrument.sh	linux-arm64  linux-musl-arm64  net  store
sh-5.2# exit
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

