### PR TITLE
Implementation of Windows E2E EC2 Default Test

### DIFF
--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -19,22 +19,22 @@ permissions:
   contents: read
 
 jobs:
-#  dotnet-e2e-ec2-default-test:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-##        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-##                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-##                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-##                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-#        aws-region: [ 'us-east-1' ]
-#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
-#    secrets: inherit
-#    with:
-#      aws-region: ${{ matrix.aws-region }}
-#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
-#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
-#
+  dotnet-e2e-ec2-default-test:
+    strategy:
+      fail-fast: false
+      matrix:
+#        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+#                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+#                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+#                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+        aws-region: [ 'us-east-1' ]
+    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ matrix.aws-region }}
+      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
+      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+
 #  dotnet-e2e-ec2-asg-test:
 #    strategy:
 #      fail-fast: false

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -41,7 +41,7 @@ jobs:
 #                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
 #                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
         aws-region: [ 'us-east-1' ]
-
+    
     uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -10,41 +10,60 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  push:
+    branches:
+      - "windows-e2e"
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  dotnet-e2e-ec2-default-test:
+#  dotnet-e2e-ec2-default-test:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+##        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+##                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+##                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+##                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+#        aws-region: [ 'us-east-1' ]
+#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+#    secrets: inherit
+#    with:
+#      aws-region: ${{ matrix.aws-region }}
+#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
+#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+
+#  dotnet-e2e-ec2-asg-test:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+##        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+##                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+##                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+##                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
+#        aws-region: [ 'us-east-1' ]
+#    
+#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
+#    secrets: inherit
+#    with:
+#      aws-region: ${{ matrix.aws-region }}
+#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
+#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+
+  dotnet-e2e-ec2-windows-test:
     strategy:
       fail-fast: false
       matrix:
-#        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-#                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-#                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-#                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+        #        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+        #                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+        #                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+        #                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
         aws-region: [ 'us-east-1' ]
-    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
-      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
-
-  dotnet-e2e-ec2-asg-test:
-    strategy:
-      fail-fast: false
-      matrix:
-#        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-#                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-#                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-#                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
-        aws-region: [ 'us-east-1' ]
-    
-    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
-    secrets: inherit
-    with:
-      aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
       staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -10,47 +10,44 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
-  push:
-    branches:
-      - "windows-e2e"
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-#  dotnet-e2e-ec2-default-test:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-##        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-##                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-##                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-##                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-#        aws-region: [ 'us-east-1' ]
-#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
-#    secrets: inherit
-#    with:
-#      aws-region: ${{ matrix.aws-region }}
-#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
-#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+  dotnet-e2e-ec2-default-test:
+    strategy:
+      fail-fast: false
+      matrix:
+#        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+#                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+#                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+#                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+        aws-region: [ 'us-east-1' ]
+    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ matrix.aws-region }}
+      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
+      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
 
-#  dotnet-e2e-ec2-asg-test:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-##        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-##                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-##                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-##                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
-#        aws-region: [ 'us-east-1' ]
-#    
-#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
-#    secrets: inherit
-#    with:
-#      aws-region: ${{ matrix.aws-region }}
-#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
-#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+  dotnet-e2e-ec2-asg-test:
+    strategy:
+      fail-fast: false
+      matrix:
+#        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+#                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+#                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+#                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
+        aws-region: [ 'us-east-1' ]
+
+    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ matrix.aws-region }}
+      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
+      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
 
   dotnet-e2e-ec2-windows-test:
     strategy:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -63,4 +63,4 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
-      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-windows.zip'

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -10,44 +10,47 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  push:
+    branches:
+      - "windows-e2e"
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  dotnet-e2e-ec2-default-test:
-    strategy:
-      fail-fast: false
-      matrix:
-#        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-#                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-#                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-#                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-        aws-region: [ 'us-east-1' ]
-    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
-    secrets: inherit
-    with:
-      aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
-      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
-
-  dotnet-e2e-ec2-asg-test:
-    strategy:
-      fail-fast: false
-      matrix:
-#        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-#                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-#                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-#                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
-        aws-region: [ 'us-east-1' ]
-
-    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
-    secrets: inherit
-    with:
-      aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
-      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+#  dotnet-e2e-ec2-default-test:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+##        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+##                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+##                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+##                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+#        aws-region: [ 'us-east-1' ]
+#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+#    secrets: inherit
+#    with:
+#      aws-region: ${{ matrix.aws-region }}
+#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
+#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+#
+#  dotnet-e2e-ec2-asg-test:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+##        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+##                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+##                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+##                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
+#        aws-region: [ 'us-east-1' ]
+#
+#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
+#    secrets: inherit
+#    with:
+#      aws-region: ${{ matrix.aws-region }}
+#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
+#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
 
   dotnet-e2e-ec2-windows-test:
     strategy:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-canary-test.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
-  push:
-    branches:
-      - "windows-e2e"
 
 permissions:
   id-token: write
@@ -35,22 +32,22 @@ jobs:
       caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
       staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
 
-#  dotnet-e2e-ec2-asg-test:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-##        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-##                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-##                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-##                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
-#        aws-region: [ 'us-east-1' ]
-#
-#    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
-#    secrets: inherit
-#    with:
-#      aws-region: ${{ matrix.aws-region }}
-#      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
-#      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
+  dotnet-e2e-ec2-asg-test:
+    strategy:
+      fail-fast: false
+      matrix:
+#        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+#                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+#                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+#                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
+        aws-region: [ 'us-east-1' ]
+
+    uses: ./.github/workflows/application-signals-dotnet-e2e-ec2-asg-test.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ matrix.aws-region }}
+      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'
+      staging_wheel_name: 'aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip'
 
   dotnet-e2e-ec2-windows-test:
     strategy:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/default
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
 #            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/default
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
 #            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
@@ -86,7 +86,8 @@ jobs:
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/default
-        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
+#        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip  -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
 #            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-default-test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/default
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip  -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
 #            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -33,7 +33,7 @@ env:
   GET_CW_AGENT_RPM_COMMAND: "wget -O ./amazon-cloudwatch-agent.msi https://amazoncloudwatch-agent.s3.amazonaws.com/windows/amd64/latest/amazon-cloudwatch-agent.msi"
 
 jobs:
-  dotnet-e2e-ec2-default-test:
+  dotnet-e2e-ec2-default-windows-test:
     runs-on: ubuntu-latest
     container:
       image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -1,0 +1,257 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the DotNet E2E Canary test for Application Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: Application Signals Enablement E2E Testing - DotNet EC2 Windows Default Use Case
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        required: true
+        type: string
+      staging_wheel_name:
+        required: false
+        default: 'aws-opentelemetry-distro'
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP_NAME: /aws/application-signals/data
+  ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
+  GET_CW_AGENT_RPM_COMMAND: "wget -O .\amazon-cloudwatch-agent.msi https://amazoncloudwatch-agent.s3.amazonaws.com/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+
+jobs:
+  dotnet-e2e-ec2-default-test:
+    runs-on: ubuntu-latest
+    container:
+      image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+#          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          ref: 'dotnetMergeBranch-windows'
+          fetch-depth: 0
+
+      - name: Initiate Gradlew Daemon
+        id: initiate-gradlew
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_IAD_TEST_ACCOUNT_ARN }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids:
+            ACCOUNT_ID, region-account/${{ inputs.aws-region }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - uses: actions/download-artifact@v3
+        if: inputs.caller-workflow-name == 'main-build'
+        with:
+          name: ${{ env.ADOT_WHEEL_NAME }}
+
+      - name: Upload main-build adot.whl to s3
+        if: inputs.caller-workflow-name == 'main-build'
+        run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
+
+      - name: Set Get ADOT Wheel command environment variable
+        working-directory: terraform/dotnet/ec2/default
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.1.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
+#        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
+  #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
+#            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
+#            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+#          else
+#            echo GET_ADOT_DISTRO_COMMAND="dotnet3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+#          fi
+
+      - name: Initiate Terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/dotnet/ec2/windows && terraform init && terraform validate"
+          cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          max_retry: 6
+          sleep_time: 60
+
+      - name: Deploy sample app via terraform and wait for endpoint to come online
+        working-directory: terraform/dotnet/ec2/default
+        run: |
+          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online. 
+          # There may be occasional failures due to transitivity issues, so try up to 2 times. 
+          # deployment_failed of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
+          # that it failed at some point
+          retry_counter=0
+          max_retry=2
+          while [ $retry_counter -lt $max_retry ]; do
+            echo "Attempt $retry_counter"
+            deployment_failed=0
+            terraform apply -auto-approve \
+              -var="aws_region=${{ inputs.aws-region }}" \
+              -var="test_id=${{ env.TESTING_ID }}" \
+              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
+              -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
+            || deployment_failed=$?
+          
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
+            fi
+          
+            # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
+            # resources created from terraform and try again.
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Destroying terraform"
+              terraform destroy -auto-approve \
+                -var="test_id=${{ env.TESTING_ID }}" 
+          
+              retry_counter=$(($retry_counter+1))
+            else
+              # If deployment succeeded, then exit the loop
+              echo "Deploy success, waiting"
+              sleep 600
+              echo "Wait end"
+              break
+            fi
+          
+            if [ $retry_counter -eq $max_retry ]; then
+              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
+              exit 1
+            fi
+          done
+
+      - name: Get the ec2 instance ami id
+        run: |
+          echo "EC2_INSTANCE_AMI=$(terraform output ec2_instance_ami)" >> $GITHUB_ENV
+        working-directory: terraform/dotnet/ec2/default
+
+      - name: Get the sample app endpoint
+        run: |
+          echo "MAIN_SERVICE_ENDPOINT=localhost:8080" >> $GITHUB_ENV
+          echo "REMOTE_SERVICE_IP=$(terraform output sample_app_remote_service_private_ip)" >> $GITHUB_ENV
+          echo "MAIN_SERVICE_INSTANCE_ID=$(terraform output main_service_instance_id)" >> $GITHUB_ENV
+        working-directory: terraform/dotnet/ec2/default
+
+      - name: Initiate Gradlew Daemon
+        if: steps.initiate-gradlew == 'failure'
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      # Validation for pulse telemetry data
+      - name: Validate generated EMF logs
+        id: log-validation
+        run: ./gradlew validator:run --args='-c dotnet/ec2/default/log-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081
+          --region ${{ inputs.aws-region }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name dotnet-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name dotnet-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Validate generated metrics
+        id: metric-validation
+        if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c dotnet/ec2/default/metric-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081
+          --region ${{ inputs.aws-region }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name dotnet-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name dotnet-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Validate generated traces
+        id: trace-validation
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c dotnet/ec2/default/trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081
+          --region ${{ inputs.aws-region }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name dotnet-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name dotnet-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Publish metric on test result
+        if: always()
+        run: |
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
+            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Failure \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --value 0.0 \
+            --region ${{ inputs.aws-region }}
+          else
+            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Failure \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --value 1.0 \
+            --region ${{ inputs.aws-region }}
+          fi
+
+      # Clean up Procedures
+      - name: Terraform destroy
+        if: always()
+        continue-on-error: true
+        working-directory: terraform/dotnet/ec2/default
+        run: |
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}"
+#          
+#      - name: Upload emf validation logs
+#        if: always()
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: emf-validation-logs
+#          path: emf-validation.log

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -115,7 +115,8 @@ jobs:
           while [ $retry_counter -lt $max_retry ]; do
             echo "Attempt $retry_counter"
             deployment_failed=0
-            terraform apply -auto-approve || deployment_failed=$?
+            terraform apply -auto-approve \
+               || deployment_failed=$?
 #            terraform apply -auto-approve \
 #              -var="aws_region=${{ inputs.aws-region }}" \
 #              -var="test_id=${{ env.TESTING_ID }}" \

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -24,8 +24,8 @@ permissions:
   contents: read
 
 env:
-#  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
-  SAMPLE_APP_ZIP: "wget -O ./dotnet-sample-app.zip https://github.com/aws-observability/aws-application-signals-test-framework/raw/dotnetMergeBranch-windows/sample-apps/dotnet/dotnet-sample-app.zip"
+  SAMPLE_APP_ZIP: "aws s3 cp s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip ./dotnet-sample-app.zip"
+#  SAMPLE_APP_ZIP: "wget -O ./dotnet-sample-app.zip https://github.com/aws-observability/aws-application-signals-test-framework/raw/dotnetMergeBranch-windows/sample-apps/dotnet/dotnet-sample-app.zip"
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}
@@ -76,14 +76,14 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
-#      - uses: actions/download-artifact@v3
-#        if: inputs.caller-workflow-name == 'main-build'
-#        with:
-#          name: ${{ env.ADOT_WHEEL_NAME }}
-#
-#      - name: Upload main-build adot.whl to s3
-#        if: inputs.caller-workflow-name == 'main-build'
-#        run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
+      - uses: actions/download-artifact@v3
+        if: inputs.caller-workflow-name == 'main-build'
+        with:
+          name: ${{ env.ADOT_WHEEL_NAME }}
+
+      - name: Upload main-build adot.whl to s3
+        if: inputs.caller-workflow-name == 'main-build'
+        run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/windows

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -104,7 +104,7 @@ jobs:
           sleep_time: 60
 
       - name: Deploy sample app via terraform and wait for endpoint to come online
-        working-directory: terraform/dotnet/ec2/default
+        working-directory: terraform/dotnet/ec2/windows
         run: |
           # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online. 
           # There may be occasional failures due to transitivity issues, so try up to 2 times. 

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -85,7 +85,7 @@ jobs:
         run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
 
       - name: Set Get ADOT Wheel command environment variable
-        working-directory: terraform/dotnet/ec2/default
+        working-directory: terraform/dotnet/ec2/windows
         run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.1.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
@@ -152,14 +152,14 @@ jobs:
       - name: Get the ec2 instance ami id
         run: |
           echo "EC2_INSTANCE_AMI=$(terraform output ec2_instance_ami)" >> $GITHUB_ENV
-        working-directory: terraform/dotnet/ec2/default
+        working-directory: terraform/dotnet/ec2/windows
 
       - name: Get the sample app endpoint
         run: |
           echo "MAIN_SERVICE_ENDPOINT=localhost:8080" >> $GITHUB_ENV
           echo "REMOTE_SERVICE_IP=$(terraform output sample_app_remote_service_private_ip)" >> $GITHUB_ENV
           echo "MAIN_SERVICE_INSTANCE_ID=$(terraform output main_service_instance_id)" >> $GITHUB_ENV
-        working-directory: terraform/dotnet/ec2/default
+        working-directory: terraform/dotnet/ec2/windows
 
       - name: Initiate Gradlew Daemon
         if: steps.initiate-gradlew == 'failure'

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -115,13 +115,14 @@ jobs:
           while [ $retry_counter -lt $max_retry ]; do
             echo "Attempt $retry_counter"
             deployment_failed=0
-            terraform apply -auto-approve \
-              -var="aws_region=${{ inputs.aws-region }}" \
-              -var="test_id=${{ env.TESTING_ID }}" \
-              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
-              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
-              -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
-            || deployment_failed=$?
+            terraform apply -auto-approve || deployment_failed=$?
+#            terraform apply -auto-approve \
+#              -var="aws_region=${{ inputs.aws-region }}" \
+#              -var="test_id=${{ env.TESTING_ID }}" \
+#              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+#              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
+#              -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
+#            || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then
               echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -95,7 +95,7 @@ jobs:
 #          else
 #            echo GET_ADOT_DISTRO_COMMAND="dotnet3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
 #          fi
-#
+
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -116,14 +116,7 @@ jobs:
             echo "Attempt $retry_counter"
             deployment_failed=0
             terraform apply -auto-approve \
-               || deployment_failed=$?
-#            terraform apply -auto-approve \
-#              -var="aws_region=${{ inputs.aws-region }}" \
-#              -var="test_id=${{ env.TESTING_ID }}" \
-#              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
-#              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
-#              -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
-#            || deployment_failed=$?
+            || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then
               echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -87,14 +87,13 @@ jobs:
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/windows
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
-#        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
-  #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
-#            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
-#            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-#          else
-#            echo GET_ADOT_DISTRO_COMMAND="dotnet3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-#          fi
+        run: |
+          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
+            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
+            echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV
+          fi
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
 #  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
-  SAMPLE_APP_ZIP: "wget -O ./dotnet-sample-app.zip https://github.com/aws-observability/aws-application-signals-test-framework/raw/dotnetE2ETests/sample-apps/dotnet/dotnet-sample-app.zip"
+  SAMPLE_APP_ZIP: "wget -O ./dotnet-sample-app.zip https://github.com/aws-observability/aws-application-signals-test-framework/raw/dotnetMergeBranch-windows/sample-apps/dotnet/dotnet-sample-app.zip"
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}
@@ -175,7 +175,7 @@ jobs:
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs
         id: log-validation
-        run: ./gradlew validator:run --args='-c dotnet/ec2/default/log-validation.yml
+        run: ./gradlew validator:run --args='-c dotnet/ec2/windows/log-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081
@@ -192,7 +192,7 @@ jobs:
       - name: Validate generated metrics
         id: metric-validation
         if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
-        run: ./gradlew validator:run --args='-c dotnet/ec2/default/metric-validation.yml
+        run: ./gradlew validator:run --args='-c dotnet/ec2/windows/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081
@@ -209,7 +209,7 @@ jobs:
       - name: Validate generated traces
         id: trace-validation
         if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
-        run: ./gradlew validator:run --args='-c dotnet/ec2/default/trace-validation.yml
+        run: ./gradlew validator:run --args='-c dotnet/ec2/windows/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -116,6 +116,11 @@ jobs:
             echo "Attempt $retry_counter"
             deployment_failed=0
             terraform apply -auto-approve \
+              -var="aws_region=${{ inputs.aws-region }}" \
+              -var="test_id=${{ env.TESTING_ID }}" \
+              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
+              -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -95,7 +95,7 @@ jobs:
 #          else
 #            echo GET_ADOT_DISTRO_COMMAND="dotnet3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
 #          fi
-
+#
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -76,18 +76,18 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
-      - uses: actions/download-artifact@v3
-        if: inputs.caller-workflow-name == 'main-build'
-        with:
-          name: ${{ env.ADOT_WHEEL_NAME }}
-
-      - name: Upload main-build adot.whl to s3
-        if: inputs.caller-workflow-name == 'main-build'
-        run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
+#      - uses: actions/download-artifact@v3
+#        if: inputs.caller-workflow-name == 'main-build'
+#        with:
+#          name: ${{ env.ADOT_WHEEL_NAME }}
+#
+#      - name: Upload main-build adot.whl to s3
+#        if: inputs.caller-workflow-name == 'main-build'
+#        run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/windows
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.1.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -94,7 +94,7 @@ jobs:
 #          else
 #            echo GET_ADOT_DISTRO_COMMAND="dotnet3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
 #          fi
-
+#
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -29,7 +29,7 @@ env:
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
-  GET_CW_AGENT_RPM_COMMAND: "wget -O .\amazon-cloudwatch-agent.msi https://amazoncloudwatch-agent.s3.amazonaws.com/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+  GET_CW_AGENT_RPM_COMMAND: "wget -O ./amazon-cloudwatch-agent.msi https://amazoncloudwatch-agent.s3.amazonaws.com/windows/amd64/latest/amazon-cloudwatch-agent.msi"
 
 jobs:
   dotnet-e2e-ec2-default-test:

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Terraform destroy
         if: always()
         continue-on-error: true
-        working-directory: terraform/dotnet/ec2/default
+        working-directory: terraform/dotnet/ec2/windows
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/windows
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.1.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file
@@ -249,10 +249,4 @@ jobs:
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"
-#          
-#      - name: Upload emf validation logs
-#        if: always()
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: emf-validation-logs
-#          path: emf-validation.log
+          

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/dotnet/ec2/windows
-        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.1.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
+        run: echo GET_ADOT_DISTRO_COMMAND="wget -O ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip; Expand-Archive -Path ./aws-distro-opentelemetry-dotnet-instrumentation-windows.zip -DestinationPath ./dotnet-distro -Force" >> $GITHUB_ENV      
 #        run: echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV      
   #          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
 #            # Reusing the adot-main-build-staging-jar bucket to store the dotnet wheel file

--- a/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
+++ b/.github/workflows/application-signals-dotnet-e2e-ec2-windows-default-test.yml
@@ -24,7 +24,8 @@ permissions:
   contents: read
 
 env:
-  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+#  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  SAMPLE_APP_ZIP: "wget -O ./dotnet-sample-app.zip https://github.com/aws-observability/aws-application-signals-test-framework/raw/dotnetE2ETests/sample-apps/dotnet/dotnet-sample-app.zip"
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}


### PR DESCRIPTION
*Description of changes:*
Implement Windows E2E EC2 Default Test

*Known Limitation & Fixing*
**Terraform cannot obtain status of SSM Document execution so a timer have been place to let the script run**

*Known Issue*
In a small chance, possible for receive remote-service trace before caller-service trace

*Tests*
https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/10515984578

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

