### PR TITLE
Add configuration for sql statements in build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -146,6 +146,15 @@ internal partial class Build : NukeBuild
             FileSystemTasks.CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
         });
 
+    private Target CopyConfiguration => _ => _
+        .After(this.AddAWSPlugins)
+        .Executes(() =>
+        {
+            var source = RootDirectory / "src" / "AWS.Distro.OpenTelemetry.AutoInstrumentation" / "configuration";
+            var dest = this.openTelemetryDistributionFolder / "configuration";
+            FileSystemTasks.CopyDirectoryRecursively(source, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Skip);
+        });
+
     private Target ExtendLicenseFile => _ => _
         .After(this.AddAWSPlugins)
         .Executes(() =>
@@ -175,6 +184,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
 
     private Target PackAWSDistribution => _ => _
         .After(this.CopyInstrumentScripts)
+        .After(this.CopyConfiguration)
         .After(this.ExtendLicenseFile)
         .Executes(() =>
         {
@@ -235,6 +245,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
         .DependsOn(this.Compile)
         .DependsOn(this.AddAWSPlugins)
         .DependsOn(this.CopyInstrumentScripts)
+        .DependsOn(this.CopyConfiguration)
         .DependsOn(this.ExtendLicenseFile)
         // .DependsOn(RunUnitTests)
         // .DependsOn(RunIntegrationTests)

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -54,13 +54,20 @@ internal sealed class AwsSpanProcessingUtil
 
     internal static readonly string SqlDialectPattern = "^(?:" + string.Join("|", GetDialectKeywords()) + ")\\b";
 
-    private const string SqlDialectKeywordsJson = "configuration/sql_dialect_keywords.json";
-
     internal static List<string> GetDialectKeywords()
     {
         try
         {
-            using (StreamReader r = new StreamReader(SqlDialectKeywordsJson))
+            string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME");
+
+            if (string.IsNullOrEmpty(otelDotnetAtuoHome))
+            {
+                Console.WriteLine("The environment variable OTEL_DOTNET_AUTO_HOME is not set or is empty.");
+            }
+
+            string SqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");
+
+            using (StreamReader r = new StreamReader(SqlDialectKeywordsJsonFullPath))
             {
                 string json = r.ReadToEnd();
                 JObject jObject = JObject.Parse(json);

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -58,14 +58,12 @@ internal sealed class AwsSpanProcessingUtil
     {
         try
         {
+            string SqlDialectKeywordsJsonFullPath = "configuration/sql_dialect_keywords.json";
             string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME");
-
-            if (string.IsNullOrEmpty(otelDotnetAtuoHome))
+            if (!string.IsNullOrEmpty(otelDotnetAtuoHome))
             {
-                Console.WriteLine("The environment variable OTEL_DOTNET_AUTO_HOME is not set or is empty.");
+                SqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");
             }
-
-            string SqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");
 
             using (StreamReader r = new StreamReader(SqlDialectKeywordsJsonFullPath))
             {

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -59,10 +59,10 @@ internal sealed class AwsSpanProcessingUtil
         try
         {
             string sqlDialectKeywordsJsonFullPath = "configuration/sql_dialect_keywords.json";
-            string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? string.Empty;
-            if (!string.IsNullOrEmpty(otelDotnetAtuoHome))
+            string otelDotnetAutoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? string.Empty;
+            if (!string.IsNullOrEmpty(otelDotnetAutoHome))
             {
-                sqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");
+                sqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAutoHome, "configuration", "sql_dialect_keywords.json");
             }
 
             using (StreamReader r = new StreamReader(sqlDialectKeywordsJsonFullPath))

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -59,7 +59,7 @@ internal sealed class AwsSpanProcessingUtil
         try
         {
             string sqlDialectKeywordsJsonFullPath = "configuration/sql_dialect_keywords.json";
-            string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? "";
+            string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? string.Empty;
             if (!string.IsNullOrEmpty(otelDotnetAtuoHome))
             {
                 sqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -58,14 +58,14 @@ internal sealed class AwsSpanProcessingUtil
     {
         try
         {
-            string SqlDialectKeywordsJsonFullPath = "configuration/sql_dialect_keywords.json";
-            string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME");
+            string sqlDialectKeywordsJsonFullPath = "configuration/sql_dialect_keywords.json";
+            string otelDotnetAtuoHome = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? "";
             if (!string.IsNullOrEmpty(otelDotnetAtuoHome))
             {
-                SqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");
+                sqlDialectKeywordsJsonFullPath = Path.Combine(otelDotnetAtuoHome, "configuration", "sql_dialect_keywords.json");
             }
 
-            using (StreamReader r = new StreamReader(SqlDialectKeywordsJsonFullPath))
+            using (StreamReader r = new StreamReader(sqlDialectKeywordsJsonFullPath))
             {
                 string json = r.ReadToEnd();
                 JObject jObject = JObject.Parse(json);


### PR DESCRIPTION
*Issue #, if available:*
This PR will fix https://github.com/aws-observability/aws-otel-dotnet-instrumentation/issues/81
*Description of changes:*
Add configuration file of SQL keywords into build and use it to determine SQL command and set aws remote operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

