### PR TITLE
Fix an issue where GetDbConnection fails if the port is not of type long

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
@@ -525,19 +525,19 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
         {
             var serverAddress = span.GetTagItem(AttributeServerAddress);
             var serverPort = span.GetTagItem(AttributeServerPort);
-            dbConnection = BuildDbConnection(serverAddress?.ToString(), serverPort == null ? null : (long)serverPort);
+            dbConnection = BuildDbConnection(serverAddress?.ToString(), serverPort == null ? null : Convert.ToInt64(serverPort));
         }
         else if (IsKeyPresent(span, AttributeNetPeerName))
         {
             var networkPeerAddress = span.GetTagItem(AttributeNetPeerName);
             var networkPeerPort = span.GetTagItem(AttributeNetPeerPort);
-            dbConnection = BuildDbConnection(networkPeerAddress?.ToString(), networkPeerPort == null ? null : (long)networkPeerPort);
+            dbConnection = BuildDbConnection(networkPeerAddress?.ToString(), networkPeerPort == null ? null : Convert.ToInt64(networkPeerPort));
         }
         else if (IsKeyPresent(span, AttributeServerSocketAddress))
         {
             var serverSocketAddress = span.GetTagItem(AttributeServerSocketAddress);
             var serverSocketPort = span.GetTagItem(AttributeServerSocketPort);
-            dbConnection = BuildDbConnection(serverSocketAddress?.ToString(), serverSocketPort == null ? null : (long)serverSocketPort);
+            dbConnection = BuildDbConnection(serverSocketAddress?.ToString(), serverSocketPort == null ? null : Convert.ToInt64(serverSocketPort));
         }
         else if (IsKeyPresent(span, AttributeDbConnectionString))
         {

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsMetricAttributesGeneratorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsMetricAttributesGeneratorTest.cs
@@ -527,6 +527,26 @@ public class AwsMetricAttributesGeneratorTest
         };
         this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
 
+        // Validate BuildDbConnection string when server port is string
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeDbSystem, "mysql" },
+            { AttributeDbName, "db_name" },
+            { AttributeServerAddress, "abc.com" },
+            { AttributeServerPort, "3306" },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
+
+        // Validate BuildDbConnection string when server port is int32
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeDbSystem, "mysql" },
+            { AttributeDbName, "db_name" },
+            { AttributeServerAddress, "abc.com" },
+            { AttributeServerPort, (long)3306 },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
+
         // Validate behaviour of DB_NAME with '|' char, SERVER_ADDRESS and SERVER_PORT exist
         attributesCombination = new Dictionary<string, object>
         {
@@ -585,6 +605,26 @@ public class AwsMetricAttributesGeneratorTest
         };
         this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
 
+        // Validate BuildDbConnection string when AttributeNetPeerPort is int32
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeDbSystem, "mysql" },
+            { AttributeDbName, "db_name" },
+            { AttributeNetPeerName, "abc.com" },
+            { AttributeNetPeerPort, 3306 },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
+
+        // Validate BuildDbConnection string when AttributeNetPeerPort is string
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeDbSystem, "mysql" },
+            { AttributeDbName, "db_name" },
+            { AttributeNetPeerName, "abc.com" },
+            { AttributeNetPeerPort, "3306" },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
+
         // Validate behaviour of DB_NAME, NET_PEER_NAME exist
         attributesCombination = new Dictionary<string, object>
         {
@@ -620,6 +660,26 @@ public class AwsMetricAttributesGeneratorTest
             { AttributeDbName, "db_name" },
             { AttributeServerSocketAddress, "abc.com" },
             { AttributeServerSocketPort, (long)3306 },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
+
+        // Validate BuildDbConnection string when AttributeServerSocketPort is int32
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeDbSystem, "mysql" },
+            { AttributeDbName, "db_name" },
+            { AttributeServerSocketAddress, "abc.com" },
+            { AttributeServerSocketPort, 3306 },
+        };
+        this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
+
+        // Validate BuildDbConnection string when AttributeServerSocketPort is string
+        attributesCombination = new Dictionary<string, object>
+        {
+            { AttributeDbSystem, "mysql" },
+            { AttributeDbName, "db_name" },
+            { AttributeServerSocketAddress, "abc.com" },
+            { AttributeServerSocketPort, "3306" },
         };
         this.ValidateRemoteResourceAttributes(attributesCombination, "DB::Connection", "db_name|abc.com|3306", false);
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/aws-otel-dotnet-instrumentation/issues/82

*Description of changes:*
Updated logic of parsing the port number so that instead of using casting (`(long)portNumber`), it instead uses the proper conversion function (`Convert.ToInt64(portNumber)`).

*Testing:*
Added unit tests before making the change where the port was either a string or an int32. The tests immediately failed with the same error in the issue above. After making the change in the parsing logic, the tests started passing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

