### PR TITLE
Update AWS SDK contract test application to use latest AWS SDK version

### DIFF
--- a/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/AmazonClientConfigHelper.cs
+++ b/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/AmazonClientConfigHelper.cs
@@ -12,7 +12,7 @@ public static class AmazonClientConfigHelper
     {
         return new T
         {
-            ServiceURL = isFault ? faultEndpoint : errorEndpoint, Timeout = defaultTimeout, RetryMode = RequestRetryMode.Legacy
+            ServiceURL = isFault ? faultEndpoint : errorEndpoint, Timeout = defaultTimeout, RetryMode = RequestRetryMode.Standard
         };
     }
 }

--- a/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/TestSimpleApp.AWSSDK.Core.csproj
+++ b/test/contract-tests/images/applications/TestSimpleApp.AWSSDK.Core/TestSimpleApp.AWSSDK.Core.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.303.15"/>
-        <PackageReference Include="AWSSDK.Kinesis" Version="3.7.301.110"/>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.308.7"/>
-        <PackageReference Include="AWSSDK.SQS" Version="3.7.301.31"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0-preview" />
+        <PackageReference Include="AWSSDK.Kinesis" Version="4.0.0-preview" />
+        <PackageReference Include="AWSSDK.S3" Version="4.0.0-preview" />
+        <PackageReference Include="AWSSDK.SQS" Version="4.0.0-preview" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
*Description of changes:*
Update AWS SDK contract test application to use latest AWS SDK version (4.0.0 - preview), and verify the backward compatibility with current instrumentation library by running the contract tests:
`====== 11 passed in 58.73s ======`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

