### PR TITLE
updated logic for generating aws.local.operation

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -97,11 +97,15 @@ internal sealed class AwsSpanProcessingUtil
     internal static string GetIngressOperation(Activity span)
     {
         string operation = span.DisplayName;
+
         if (ShouldUseInternalOperation(span))
         {
             operation = InternalOperation;
         }
-        else if (!IsValidOperation(span, operation))
+
+        // workaround for now so that both Server and Consumer spans have same operation
+        // TODO: Update this and other languages so that all of them set the operation during propagation.
+        else if (!IsValidOperation(span, operation) || IsKeyPresent(span, AttributeUrlPath))
         {
             operation = GenerateIngressOperation(span);
         }

--- a/test/contract-tests/tests/test/amazon/efcore/efcore_test.py
+++ b/test/contract-tests/tests/test/amazon/efcore/efcore_test.py
@@ -43,15 +43,15 @@ class EfCoreTest(ContractTestBase):
             0,
             0,
             request_method="GET",
-            local_operation="GET /blogs/{id}"
+            local_operation="GET /blogs"
         )
 
     def test_delete_success(self) -> None:
         self.do_test_requests(
-            "/blogs/1", "DELETE", 200, 0, 0, request_method="DELETE", local_operation="DELETE /blogs/{id}"
+            "/blogs/1", "DELETE", 200, 0, 0, request_method="DELETE", local_operation="DELETE /blogs"
         )
     def test_error(self) -> None:
-        self.do_test_requests("/blogs/100", "GET", 404, 1, 0, request_method="GET", local_operation="GET /blogs/{id}")
+        self.do_test_requests("/blogs/100", "GET", 404, 1, 0, request_method="GET", local_operation="GET /blogs")
 
     @override
     def _assert_aws_span_attributes(self, resource_scope_spans: List[ResourceScopeSpan], path: str, **kwargs) -> None:

--- a/test/contract-tests/tests/test/amazon/netcore/netcore_test.py
+++ b/test/contract-tests/tests/test/amazon/netcore/netcore_test.py
@@ -36,11 +36,11 @@ class NetCoreTest(ContractTestBase):
         self.do_test_requests("/fault", "GET", 500, 0, 1, request_method="GET", local_operation="GET /fault")
 
     def test_success_post(self) -> None:
-        self.do_test_requests("/success/postmethod", "POST", 200, 0, 0, request_method="POST", local_operation="POST /success/postmethod")
+        self.do_test_requests("/success/postmethod", "POST", 200, 0, 0, request_method="POST", local_operation="POST /success")
     def test_error_post(self) -> None:
-        self.do_test_requests("/error/postmethod", "POST", 400, 1, 0, request_method="POST", local_operation="POST /error/postmethod")
+        self.do_test_requests("/error/postmethod", "POST", 400, 1, 0, request_method="POST", local_operation="POST /error")
     def test_fault_post(self) -> None:
-        self.do_test_requests("/fault/postmethod", "POST", 500, 0, 1, request_method="POST", local_operation="POST /fault/postmethod")
+        self.do_test_requests("/fault/postmethod", "POST", 500, 0, 1, request_method="POST", local_operation="POST /fault")
 
     @override
     def _assert_aws_span_attributes(self, resource_scope_spans: List[ResourceScopeSpan], path: str, **kwargs) -> None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
updated logic for generating aws.local.operation so that both Server and Consumer have the same operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

