### PR TITLE
Added auto instrumentation scripts and updated GH workflow for release

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -53,6 +53,20 @@ jobs:
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
+      
+      - name: Upload bash installation script
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-otel-dotnet-install.sh
+          path: InstallationScripts/aws-otel-dotnet-install.sh
+
+      - name: Upload psm1 installation script
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: AWS.Otel.DotNet.Auto.psm1
+          path: InstallationScripts/AWS.Otel.DotNet.Auto.psm1
 
       - name: Upload Artifact on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -98,8 +98,10 @@ jobs:
         run: |
           DEV_VERSION="${{ github.event.inputs.version }}.dev0"
           sed -i "s/public static string version = \".*\";/public static string version = \"${DEV_VERSION}\";/" src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
+          sed -i "s/public static string version = \".*\";/public static string version = \"${VERSION}\";/" build/Version.cs
           VERSION="${{ github.event.inputs.version }}"
           git add src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
+          git add build/Build.InstallationScripts.cs
           git commit -m "Prepare main for next development cycle: Update version to $DEV_VERSION"
           git push --set-upstream origin "prepare-main-for-next-dev-cycle-${VERSION}"
 

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           DEV_VERSION="${{ github.event.inputs.version }}.dev0"
           sed -i "s/public static string version = \".*\";/public static string version = \"${DEV_VERSION}\";/" src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
-          sed -i "s/public static string version = \".*\";/public static string version = \"${VERSION}\";/" build/Version.cs
+          sed -i "s/private readonly string version = \".*\";/private readonly string version = \"${DEV_VERSION}\";/" build/Build.InstallationScripts.cs
           VERSION="${{ github.event.inputs.version }}"
           git add src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
           git add build/Build.InstallationScripts.cs

--- a/.github/workflows/pre_release_prepare.yml
+++ b/.github/workflows/pre_release_prepare.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Update version in file
         run: |
           sed -i "s/public static string version = \".*\";/public static string version = \"${VERSION}\";/" src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
+          sed -i "s/public static string version = \".*\";/public static string version = \"${VERSION}\";/" build/Build.InstallationScripts.cs
           git commit -am "Update version to ${VERSION}"
           git push origin "v${VERSION}_release"
 

--- a/.github/workflows/pre_release_prepare.yml
+++ b/.github/workflows/pre_release_prepare.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Update version in file
         run: |
           sed -i "s/public static string version = \".*\";/public static string version = \"${VERSION}\";/" src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs
-          sed -i "s/public static string version = \".*\";/public static string version = \"${VERSION}\";/" build/Build.InstallationScripts.cs
+          sed -i "s/private readonly string version = \".*\";/private readonly string version = \"${VERSION}\";/" build/Build.InstallationScripts.cs
           git commit -am "Update version to ${VERSION}"
           git push origin "v${VERSION}_release"
 

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -69,6 +69,18 @@ jobs:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: ./artifacts/linux/arm64-musl
 
+      - name: Download bash installation script
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-otel-dotnet-install.sh
+          path: ./installationScripts
+      
+      - name: Download psm1 installation script
+        uses: actions/download-artifact@v3
+        with:
+          name: AWS.Otel.DotNet.Auto.psm1
+          path: ./installationScripts
+
       - name: Configure AWS credentials for Private S3 Bucket
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -83,6 +95,8 @@ jobs:
           base=$(basename "$file")
           aws s3 cp "$file" "${{ env.RELEASE_PRIVATE_S3 }}/$PREFIX/$base"
           done
+          aws s3 cp ./installationScripts/aws-otel-dotnet-install.sh "${{ env.RELEASE_PRIVATE_S3 }}/$PREFIX/aws-otel-dotnet-install.sh"
+          aws s3 cp ./installationScripts/AWS.Otel.DotNet.Auto.psm1 "${{ env.RELEASE_PRIVATE_S3 }}/$PREFIX/AWS.Otel.DotNet.Auto.psm1"
 
       # Publish to GitHub releases
       - name: Create GH release
@@ -108,6 +122,12 @@ jobs:
             $base \
             --clobber
           done
+          gh release upload "v${{ github.event.inputs.version }}" \
+            ./installationScripts/aws-otel-dotnet-install.sh \
+            --clobber
+          gh release upload "v${{ github.event.inputs.version }}" \
+            ./installationScripts/AWS.Otel.DotNet.Auto.psm1 \
+            --clobber
 
   release-image:
     # We want to build and release nuget first so that if it fails, it fails before publishing to private ECR

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ apply some small configuration changes, and our OpenTelemetry friends takes care
 1. Having one of [VSCode](https://code.visualstudio.com/docs/languages/dotnet), Visual Studio, or ReSharper installed
 2. Having dotnet cli installed.
 
+## Important
+
+Although this repository is released under the Apache-2.0 license, some Dockerfiles uses Windows as a base image, which is licensed under the following terms https://learn.microsoft.com/en-us/virtualization/windowscontainers/images-eula.
+
 ## Building the Project
 
 ### Building Locally

--- a/build/Build.InstallationScripts.cs
+++ b/build/Build.InstallationScripts.cs
@@ -9,6 +9,8 @@ internal partial class Build : NukeBuild
 {
     private readonly AbsolutePath installationScriptsFolder = RootDirectory / "bin" / "InstallationScripts";
 
+    public static string version = "1.2.0.dev0";
+
     public Target BuildInstallationScripts => _ => _
         .After(this.Clean)
         .Executes(() =>
@@ -20,7 +22,7 @@ internal partial class Build : NukeBuild
                 var scriptFile = this.installationScriptsFolder / templateFile.Name.Replace(".template", string.Empty);
                 FileSystemTasks.CopyFile(templateFile, scriptFile);
                 scriptFile.UpdateText(x =>
-                    x.Replace("{{VERSION}}", VersionHelper.GetVersion()));
+                    x.Replace("{{VERSION}}", version));
             }
         });
 }

--- a/build/Build.InstallationScripts.cs
+++ b/build/Build.InstallationScripts.cs
@@ -8,8 +8,7 @@ using Nuke.Common.IO;
 internal partial class Build : NukeBuild
 {
     private readonly AbsolutePath installationScriptsFolder = RootDirectory / "bin" / "InstallationScripts";
-
-    public static string version = "1.2.0.dev0";
+    private readonly string version = "1.2.0.dev0";
 
     public Target BuildInstallationScripts => _ => _
         .After(this.Clean)
@@ -22,7 +21,7 @@ internal partial class Build : NukeBuild
                 var scriptFile = this.installationScriptsFolder / templateFile.Name.Replace(".template", string.Empty);
                 FileSystemTasks.CopyFile(templateFile, scriptFile);
                 scriptFile.UpdateText(x =>
-                    x.Replace("{{VERSION}}", version));
+                    x.Replace("{{VERSION}}", this.version));
             }
         });
 }

--- a/instrument.sh
+++ b/instrument.sh
@@ -144,7 +144,7 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
       SUFIX="dll"
       ;;
     *)
-      echo "BUG: Invalid OS_TYPE. Submit an issue in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation." >&2
+      echo "BUG: Invalid OS_TYPE. Submit an issue in https://github.com/aws-observability/aws-otel-dotnet-instrumentation." >&2
       return 1
       ;;
   esac
@@ -170,6 +170,16 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
   else
     export CORECLR_PROFILER_PATH="$OTEL_DOTNET_AUTO_HOME/$DOTNET_RUNTIME_ID/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
   fi
+
+  # AWS OTEL DOTNET 
+  export OTEL_DOTNET_AUTO_PLUGINS="AWS.Distro.OpenTelemetry.AutoInstrumentation.Plugin, AWS.Distro.OpenTelemetry.AutoInstrumentation"
+  export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+  export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4316"
+  export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT="http://127.0.0.1:4316/v1/metrics"
+  export OTEL_METRICS_EXPORTER="none"
+  export OTEL_AWS_APPLICATION_SIGNALS_ENABLED="true"
+  export OTEL_TRACES_SAMPLER="xray"
+  export OTEL_TRACES_SAMPLER_ARG="endpoint=http://127.0.0.1:2000"
 fi
 
 exec "$@"

--- a/sample-applications/integration-test-app/build-and-start-application.sh
+++ b/sample-applications/integration-test-app/build-and-start-application.sh
@@ -20,5 +20,5 @@ check_if_step_failed_and_exit "There was an error moving OpenTelemetryDistributi
 docker build -t aspnetapp .
 check_if_step_failed_and_exit "There was an error building the docker container, exiting"
 
-docker-compose up 
+docker compose up 
 check_if_step_failed_and_exit "There was an error starting up the sample app, exiting"

--- a/script-templates/AWS.Otel.DotNet.Auto.psm1.template
+++ b/script-templates/AWS.Otel.DotNet.Auto.psm1.template
@@ -38,7 +38,7 @@ function Get-Current-InstallDir() {
 }
 
 function Get-Newest-InstallVersion() { 
-    $query = "https://api.github.com/repos/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest"
+    $query = "https://api.github.com/repos/aws-observability/aws-otel-dotnet-instrumentation/releases/latest"
 
     $response = Invoke-WebRequest -Uri $query -UseBasicParsing
     $responseJson = $response.Content | ConvertFrom-Json
@@ -48,7 +48,7 @@ function Get-Newest-InstallVersion() {
 }
 
 function Get-CLIInstallDir-From-InstallDir([string]$InstallDir) {
-    $dir = "OpenTelemetry .NET AutoInstrumentation"
+    $dir = "AWS Distro for OpenTelemetry AutoInstrumentation"
     
     if ($InstallDir -eq "<auto>") {
         return (Join-Path $Env:ProgramFiles $dir)
@@ -186,7 +186,8 @@ function Remove-Windows-Service([string]$WindowsServiceName) {
         "DOTNET_SHARED_STORE",
         "DOTNET_STARTUP_HOOKS",
         # OpenTelemetry
-        "OTEL_DOTNET_"
+        "OTEL_DOTNET_",
+        "OTEL_"
     )
 
     $regPath = "HKLM:SYSTEM\CurrentControlSet\Services\"
@@ -291,10 +292,10 @@ function Is-Greater-Version($v1, $v2) {
 
 <#
     .SYNOPSIS
-    Installs OpenTelemetry .NET Automatic Instrumentation.
+    Installs AWS Distro for OpenTelemetry .NET Automatic Instrumentation.
     .PARAMETER InstallDir
     Default: <auto> - the default path is Program Files dir.
-    Install path of the OpenTelemetry .NET Automatic Instrumentation
+    Install path of the AWS Distro for OpenTelemetry .NET Automatic Instrumentation
     Possible values: <auto>, (Custom path)
 #>
 function Install-OpenTelemetryCore() {
@@ -346,7 +347,7 @@ function Install-OpenTelemetryCore() {
     } 
     catch {
         $message = $_
-        Write-Error "Could not setup OpenTelemetry .NET Automatic Instrumentation. $message"
+        Write-Error "Could not setup AWS Distro for OpenTelemetry .NET Automatic Instrumentation. $message"
     } 
     finally {
         if ($archivePath -and $deleteArchive) {
@@ -358,7 +359,7 @@ function Install-OpenTelemetryCore() {
 
 <#
     .SYNOPSIS
-    Uninstalls OpenTelemetry .NET Automatic Instrumentation.
+    Uninstalls AWS Distro for OpenTelemetry .NET Automatic Instrumentation.
 #>
 function Uninstall-OpenTelemetryCore() {
     $installDir = Get-Current-InstallDir
@@ -393,7 +394,7 @@ function Uninstall-OpenTelemetryCore() {
 
 <#
     .SYNOPSIS
-    Update OpenTelemetry .NET Automatic Instrumentation.
+    Update AWS Distro for OpenTelemetry .NET Automatic Instrumentation.
     .PARAMETER RegisterIIS
     Registers IIS 
 #>
@@ -410,12 +411,12 @@ function Update-OpenTelemetryCore() {
 
     $newestInstallVersion = Get-Newest-InstallVersion
     if (-not(Is-Greater-Version $newestInstallVersion $currentInstallVersion)) {
-        Write-Warning "Newest version of OpenTelemetry .NET Automatic Instrumentation is already installed."
+        Write-Warning "Newest version of AWS Distro for OpenTelemetry .NET Automatic Instrumentation is already installed."
 
         return
     }
 
-    Write-Information -MessageData "Updating OpenTelemetry .NET Automatic Instrumentation from $($currentInstallVersion) to $($newestInstallVersion)." -InformationAction Continue
+    Write-Information -MessageData "Updating AWS Distro for OpenTelemetry .NET Automatic Instrumentation from $($currentInstallVersion) to $($newestInstallVersion)." -InformationAction Continue
 
     $installDir = Get-Current-InstallDir
 

--- a/script-templates/aws-otel-dotnet-install.sh.template
+++ b/script-templates/aws-otel-dotnet-install.sh.template
@@ -50,12 +50,12 @@ test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-au
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
 test -z "$VERSION" && VERSION="v{{VERSION}}"
 
-RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
-ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"
+RELEASES_URL="https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases"
+ARCHIVE="aws-distro-opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"
 
 # In case of Linux, use architecture in the download path
 if echo "$OS_TYPE" | grep -q "linux"; then
-  ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE-$ARCHITECTURE.zip"
+  ARCHIVE="aws-distro-opentelemetry-dotnet-instrumentation-$OS_TYPE-$ARCHITECTURE.zip"
 fi
 
 TMPFILE="$TMPDIR/$ARCHIVE"

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -112,7 +112,6 @@ public class Plugin
             .Build();
 
             Resource resource = provider.GetResource();
-            resource.Attributes.ToList().ForEach(attribute => Console.WriteLine(attribute.Key + " " + attribute.Value));
             BaseProcessor<Activity> spanMetricsProcessor = AwsSpanMetricsProcessorBuilder.Create(resource).Build();
             tracerProvider.AddProcessor(spanMetricsProcessor);
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the installation script templates so that when we build the application, the scripts are built accordingly. Also updated the templates to use the AWS Otel Distro instead of the upstream Otel Distro. I also updated the README to reflect that we are using DockerFiles for windows images that fall under the [Windows EULA Agreement](https://learn.microsoft.com/en-us/virtualization/windowscontainers/images-eula)

*Testing:*
Tested that the scripts on both linux and windows and made sure they are working as expected. Set the version to 1.2.0 since that's the latest release and ran the script aws-otel-dotnet-install.sh which basically downloads the 1.2.0 from the releases page and unpacks the zip file. Replaced the unpacked contents with the latest contents by running build.sh and copying the files from the OpentelemetryDistro folder. Finally ran the instrument.sh file to add the instrumentation env vars and when starting the sample app, it was instrumented as expected. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

