### PR TITLE
Added logic to run sampler a second time after http instrumentation libraries

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
@@ -25,6 +25,8 @@
     <!-- TODO: Need to look into release those packages before GA -->
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Sampler.AWS" Version="0.1.0-alpha.2" />

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -249,6 +249,8 @@ public class Plugin
             return;
         }
 
+        // We should sample the parent span only as any trace flags set on the parent
+        // automatically propagates to all child spans (the X-Ray sampler is wrapped by ParentBasedSampler).
         if (activity.Parent != null)
         {
             return;

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -167,7 +167,7 @@ public class Plugin
         // them against the xray sampler. Without this, the sampler will be run twice, once by the sdk and a second time
         // after http instrumentation happens which messes up the frontend sampler graphs.
         Sampler alwaysRecordSampler;
-        if (BackupSamplerEnabled == "true")
+        if (BackupSamplerEnabled == "true" && this.sampler.GetType() == typeof(AWSXRayRemoteSampler))
         {
             alwaysRecordSampler = AlwaysRecordSampler.Create(new ParentBasedSampler(new AlwaysOnSampler()));
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This new function runs the sampler a second time after the needed attributes (such as UrlPath and HttpTarget) are finally available from the http instrumentation libraries. The sampler hooked into the Opentelemetry SDK runs right before any activity is started so for the purposes of our X-Ray sampler, that isn't going to work and breaks the X-Ray functionality. Running it a second time after http instrumentation libraries are run allows us to retain the sampler functionality.

Below is the stack trace showing the sampler running before the instrumentation libraries are started.
```
   at OpenTelemetry.Sampler.AWS.AWSXRayRemoteSampler.ShouldSample(SamplingParameters& samplingParameters) in /local/home/heayh/pulse-dotnet/opentelemetry-dotnet-contrib/src/OpenTelemetry.Sampler.AWS/AWSXRayRemoteSampler.cs:line 86
   at AWS.Distro.OpenTelemetry.AutoInstrumentation.AlwaysRecordSampler.ShouldSample(SamplingParameters& samplingParameters) in /local/home/heayh/pulse-dotnet/aws-otel-dotnet-instrumentation+sampler/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AlwaysRecordSampler.cs:line 70
   at OpenTelemetry.Trace.TracerProviderSdk.RunGetRequestedDataOtherSampler(Activity activity)
   at OpenTelemetry.Trace.TracerProviderSdk.<>c__DisplayClass12_1.<.ctor>b__9(Activity activity)
   at System.Diagnostics.ActivitySource.<>c.<NotifyActivityStart>b__24_0(ActivityListener listener, Object obj)
   at System.Diagnostics.SynchronizedList`1.EnumWithAction(Action`2 action, Object arg)
   at System.Diagnostics.ActivitySource.NotifyActivityStart(Activity activity)
   at System.Diagnostics.Activity.Start()
```

Below is also a comment from AspNetCore instrumentation library mentioning that the required attributes are only available after sampling decision is made: 
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs#L91-L99

Finally, I opened this discussion and in there is a slack thread going through a similar issue: 
https://github.com/open-telemetry/opentelemetry-dotnet/discussions/5839

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

