### PR TITLE
Set sampler directly to remove overhead of AlwaysRecordSampler

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -144,15 +144,20 @@ public class Plugin
     /// <returns>Returns configured builder</returns>
     public TracerProviderBuilder AfterConfigureTracerProvider(TracerProviderBuilder builder)
     {
+        var resourceBuilder = this.ResourceBuilderCustomizer(ResourceBuilder.CreateDefault());
+        var resource = resourceBuilder.Build();
+        Sampler sampler = SamplerUtil.GetSampler(resource);
+
         if (this.IsApplicationSignalsEnabled())
         {
             Logger.Log(LogLevel.Information, "AWS Application Signals enabled");
+            Sampler alwaysRecordSampler = AlwaysRecordSampler.Create(sampler);
+            builder.SetSampler(alwaysRecordSampler);
         }
-
-        var resourceBuilder = this.ResourceBuilderCustomizer(ResourceBuilder.CreateDefault());
-        var resource = resourceBuilder.Build();
-        Sampler alwaysRecordSampler = AlwaysRecordSampler.Create(SamplerUtil.GetSampler(resource));
-        builder.SetSampler(alwaysRecordSampler);
+        else
+        {
+            builder.SetSampler(sampler);
+        }
 
         return builder;
     }


### PR DESCRIPTION
*Description of changes:*
When application signals feature is not enabled, don't wrap AlwaysRecordSampler since it will mark all spans as recorded and introduce performance overhead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

