### PR TITLE
Added resource detectors and attributes for trace instrumentation

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -163,14 +163,14 @@ public class Plugin
     }
 
     /// <summary>
-    /// To configure Resource
-    /// TODO: Add versioning similar to Python
+    /// To configure Resource with resource detectors and <see cref="DistroAttributes"/>
+    /// Check <see cref="ResourceBuilderCustomizer"/> for more information.
     /// </summary>
     /// <param name="builder"><see cref="ResourceBuilder"/> Provider to configure</param>
     /// <returns>Returns configured builder</returns>
     public ResourceBuilder ConfigureResource(ResourceBuilder builder)
     {
-        builder.AddAttributes(DistroAttributes);
+        this.ResourceBuilderCustomizer(builder);
         return builder;
     }
 


### PR DESCRIPTION
*Description of changes:*
Before this change, only metrics had the resource detector attributes setup. Updated the ConfigureResource plugin function to not only set the distro resource attributes but also use the resource detectors. The ConfigureResource function is called by upstream to configure the resource attached to the trace exporter. This also means that these will apply to all spans even if application signals is disabled. 

Below is an example log for an activity from an EC2 instance. 
```
Activity.TraceId:            8cfa5eb16e6cff7885583babf28e5b9b
Activity.SpanId:             7bbbe008cde165b3
Activity.TraceFlags:         Recorded
Activity.ActivitySourceName: OpenTelemetry.Instrumentation.AspNetCore
Activity.ActivitySourceVersion: 1.9.0.42
Activity.DisplayName:        GET outgoing-http-call
Activity.Kind:               Server
Activity.StartTime:          2024-09-19T22:02:51.6706330Z
Activity.Duration:           00:00:01.5405903
Activity.Tags:
    server.address: localhost
    server.port: 8080
    http.request.method: GET
    url.scheme: http
    url.path: /outgoing-http-call
    network.protocol.version: 1.1
    user_agent.original: curl/8.5.0
    http.route: outgoing-http-call
    http.response.status_code: 200
Resource associated with Activity:
    cloud.provider: aws
    cloud.platform: aws_ec2
    host.name: ip-172-31-44-9.ec2.internal
    cloud.account.id: 858348110546
    cloud.availability_zone: us-east-1a
    host.id: i-06f8144b6d8631b00
    host.type: t4g.medium
    cloud.region: us-east-1
    telemetry.distro.name: aws-otel-dotnet-instrumentation
    telemetry.distro.version: 1.3.0.dev0-aws
    process.owner: ec2-user
    process.pid: 31272
    process.runtime.description: .NET 6.0.32
    process.runtime.name: .NET
    process.runtime.version: 6.0.32
    container.id: 2
    telemetry.sdk.name: opentelemetry
    telemetry.sdk.language: dotnet
    telemetry.sdk.version: 1.9.0
    service.name: aws-otel-integ-test
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

