### PR TITLE
Sign local build of OpenTelemetry.Instrumentation.AWS

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -9,6 +9,9 @@
     <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Remove following two lines when push back to upstream since it is only for local build -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../buildtools/awsoteldotnet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <!--Do not run Package Baseline Validation as this package has never released a stable version.


### PR DESCRIPTION
*Description of changes:*
It fixed the following error when doing instrumentation for .NET Framework application.

> Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.TypeInitializationException: The type initializer for 'OpenTelemetry.AutoInstrumentation.Loader.Loader' threw an exception. ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.IO.FileLoadException: Could not load file or assembly 'OpenTelemetry.Instrumentation.AWS, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
>    at AWS.Distro.OpenTelemetry.AutoInstrumentation.Plugin.BeforeConfigureTracerProvider(TracerProviderBuilder builder)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

