### PR TITLE
Filter service requests and support sampling rule for X-Ray Sampler in .NET Framework

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -224,6 +224,26 @@ public class Plugin
                 this.ShouldSampleParent(activity);
             }
         };
+
+#if NETFRAMEWORK
+        options.FilterHttpWebRequest = request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/GetSamplingRules" || request.RequestUri?.AbsolutePath == "/SamplingTargets")
+            {
+                return false;
+            }
+
+            return true;
+        };
+
+        options.EnrichWithHttpWebResponse = (activity, request) =>
+        {
+            if (this.sampler != null && this.sampler.GetType() == typeof(AWSXRayRemoteSampler))
+            {
+                this.ShouldSampleParent(activity);
+            }
+        };
+#endif
     }
 
     /// <summary>

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -207,6 +207,7 @@ public class Plugin
     /// <param name="options"><see cref="HttpClientTraceInstrumentationOptions"/> options to configure</param>
     public void ConfigureTracesOptions(HttpClientTraceInstrumentationOptions options)
     {
+#if !NETFRAMEWORK
         options.FilterHttpRequestMessage = request =>
         {
             if (request.RequestUri?.AbsolutePath == "/GetSamplingRules" || request.RequestUri?.AbsolutePath == "/SamplingTargets")
@@ -224,6 +225,7 @@ public class Plugin
                 this.ShouldSampleParent(activity);
             }
         };
+#endif
 
 #if NETFRAMEWORK
         options.FilterHttpWebRequest = request =>
@@ -236,7 +238,7 @@ public class Plugin
             return true;
         };
 
-        options.EnrichWithHttpWebResponse = (activity, request) =>
+        options.EnrichWithHttpWebRequest = (activity, request) =>
         {
             if (this.sampler != null && this.sampler.GetType() == typeof(AWSXRayRemoteSampler))
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix .NET Framework support of sampling rule like #107 and filter GetSamplingRules/GetSamplingTargets API calls from X-Ray Sampler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

