### PR TITLE
Added logic to flush remaining metrics during shutdown

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanMetricsProcessorBuilder.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanMetricsProcessorBuilder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 
 namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
@@ -23,24 +24,27 @@ public class AwsSpanMetricsProcessorBuilder
     // ActivitySource.Name?
     private static readonly string DefaultScopeName = "AwsSpanMetricsProcessor";
     private readonly Resource resource;
+    private readonly MeterProvider provider;
 
     // Optional builder elements
     private IMetricAttributeGenerator generator = DefaultGenerator;
     private string scopeName = DefaultScopeName;
 
-    private AwsSpanMetricsProcessorBuilder(Resource resource)
+    private AwsSpanMetricsProcessorBuilder(Resource resource, MeterProvider provider)
     {
         this.resource = resource;
+        this.provider = provider;
     }
 
     /// <summary>
     /// Configure new AwsSpanMetricsProcessorBuilder
     /// </summary>
     /// <param name="resource"><see cref="Resource"/>Resource to store</param>
+    /// <param name="provider"><see cref="MeterProvider"/>MeterProvider to store</param>
     /// <returns>New AwsSpanMetricsProcessorBuilder</returns>
-    public static AwsSpanMetricsProcessorBuilder Create(Resource resource)
+    public static AwsSpanMetricsProcessorBuilder Create(Resource resource, MeterProvider provider)
     {
-        return new AwsSpanMetricsProcessorBuilder(resource);
+        return new AwsSpanMetricsProcessorBuilder(resource, provider);
     }
 
     /// <summary>
@@ -88,7 +92,7 @@ public class AwsSpanMetricsProcessorBuilder
         Histogram<long> faultHistogram = meter.CreateHistogram<long>(Fault);
         Histogram<double> latencyHistogram = meter.CreateHistogram<double>(Latency, LatencyUnits);
         return AwsSpanMetricsProcessor.Create(
-            errorHistogram, faultHistogram, latencyHistogram, this.generator, this.resource);
+            errorHistogram, faultHistogram, latencyHistogram, this.generator, this.resource, this.provider);
     }
 
     /// <summary>

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -121,7 +121,7 @@ public class Plugin
             .Build();
 
             Resource resource = provider.GetResource();
-            BaseProcessor<Activity> spanMetricsProcessor = AwsSpanMetricsProcessorBuilder.Create(resource).Build();
+            BaseProcessor<Activity> spanMetricsProcessor = AwsSpanMetricsProcessorBuilder.Create(resource, provider).Build();
             tracerProvider.AddProcessor(spanMetricsProcessor);
         }
     }

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsSpanMetricsProcessorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsSpanMetricsProcessorTest.cs
@@ -6,6 +6,8 @@ using System.Diagnostics.Metrics;
 using System.Reflection;
 using HarmonyLib;
 using Moq;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsAttributeKeys;
@@ -30,6 +32,7 @@ public class AwsSpanMetricsProcessorTest : IDisposable
     private AwsSpanMetricsProcessor awsSpanMetricsProcessor;
     private Mock<AwsMetricAttributeGenerator> generator = new Mock<AwsMetricAttributeGenerator>();
     private Resource resource = Resource.Empty;
+    private MeterProvider provider = Sdk.CreateMeterProviderBuilder().Build();
     private Meter meter = new Meter("test");
     private Histogram<long> errorHistogram;
     private Histogram<long> faultHistogram;
@@ -72,7 +75,7 @@ public class AwsSpanMetricsProcessorTest : IDisposable
                     list.Add(new KeyValuePair<string, object>(instrument.Name, new KeyValuePair<double, object>(measurement, tags[0])));
                     GlobalCallbackData.CallList = list;
                 });
-        this.awsSpanMetricsProcessor = AwsSpanMetricsProcessor.Create(this.errorHistogram, this.faultHistogram, this.latencyHistogram, this.generator.Object, this.resource);
+        this.awsSpanMetricsProcessor = AwsSpanMetricsProcessor.Create(this.errorHistogram, this.faultHistogram, this.latencyHistogram, this.generator.Object, this.resource, this.provider);
     }
 
     [Fact]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added logic to flush remaining metrics during shutdown from the AwsSpanMetricProcessor. 

*Testing:*
Tested by setting the metric and trace exporting interval to 1 minute. Before the change, shutting down the application before the minute ends only exports the trace to the collector. After the change, both traces and metrics are always exported before application shutdown. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

