### PR TITLE
Added unsampledSpan processor implementation

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsAttributeKeys.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsAttributeKeys.cs
@@ -25,6 +25,7 @@ internal sealed class AwsAttributeKeys
     internal static readonly string AttributeAWSOperationName = "aws.operation";
     internal static readonly string AttributeAWSRegion = "aws.region";
     internal static readonly string AttributeAWSRequestId = "aws.requestId";
+    internal static readonly string AttributeAWSTraceFlagSampled = "aws.trace.flag.sampled";
 
     // The below semantic names were copied over from various sources.
     // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/4c6474259ccb08a41eb45ea6424243d4d2c707db/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsBatchUnsampledSpanExportProcessor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsBatchUnsampledSpanExportProcessor.cs
@@ -9,7 +9,7 @@ using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsAttributeKeys;
 /// AwsBatchUnsampledSpanExportProcessor class that functions similar to BatchActivityExportProcessor
 /// having the same input parameters and the same default values. However, the difference is that
 /// BatchActivityExportProcessor only exports sampled (or recorded) activities while AwsBatchUnsampledSpanExportProcessor
-/// sets the AttributeAWSTraceFlagSampled to false if activity is not sampled but exports both sampled and and unsampled data.
+/// sets the AttributeAWSTraceFlagSampled to false if activity is not sampled and only exports unsampled activities.
 /// </summary>
 internal class AwsBatchUnsampledSpanExportProcessor : BatchExportProcessor<Activity>
 {
@@ -37,11 +37,9 @@ internal class AwsBatchUnsampledSpanExportProcessor : BatchExportProcessor<Activ
         if (!data.Recorded)
         {
             data.SetTag(AttributeAWSTraceFlagSampled, "false");
-        }
 
-        // simply put, we only need to call the export function and it will do everything for us
-        // We don't need to check on sampled or not because the original implementation only calls
-        // export on sampled data but this one will call it on everything.
-        this.OnExport(data);
+            // Only exporting unsampled traces as this is the purpose of this processor.
+            this.OnExport(data);
+        }
     }
 }

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsBatchUnsampledSpanExportProcessor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsBatchUnsampledSpanExportProcessor.cs
@@ -5,6 +5,12 @@ using System.Diagnostics;
 using OpenTelemetry;
 using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsAttributeKeys;
 
+/// <summary>
+/// AwsBatchUnsampledSpanExportProcessor class that functions similar to BatchActivityExportProcessor
+/// having the same input parameters and the same default values. However, the difference is that
+/// BatchActivityExportProcessor only exports sampled (or recorded) activities while AwsBatchUnsampledSpanExportProcessor
+/// sets the AttributeAWSTraceFlagSampled to false if activity is not sampled but exports both sampled and and unsampled data.
+/// </summary>
 internal class AwsBatchUnsampledSpanExportProcessor : BatchExportProcessor<Activity>
 {
     /// <summary>
@@ -21,15 +27,13 @@ internal class AwsBatchUnsampledSpanExportProcessor : BatchExportProcessor<Activ
     }
 
     /// <inheritdoc />
-    /// TODO: There is an OTEL discussion to add BeforeEnd to allow us to write to spans. Below is a hack and goes
-    /// against the otel specs (not to edit span in OnEnd) but is required for the time being.
-    /// Add BeforeEnd to have a callback where the span is still writeable open-telemetry/opentelemetry-specification#1089
-    /// https://github.com/open-telemetry/opentelemetry-specification/issues/1089
-    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onendspan
     public override void OnEnd(Activity data)
     {
-        // q: looks like on start just adds attribute to activity. Why not add it on end?
-        // ans: main answer is because its out of spec to edit an activity on end.
+        // TODO: There is an OTEL discussion to add BeforeEnd to allow us to write to spans. Below is a hack and goes
+        // against the otel specs (not to edit span in OnEnd) but is required for the time being.
+        // Add BeforeEnd to have a callback where the span is still writeable open-telemetry/opentelemetry-specification#1089
+        // https://github.com/open-telemetry/opentelemetry-specification/issues/1089
+        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onendspan
         if (!data.Recorded)
         {
             data.SetTag(AttributeAWSTraceFlagSampled, "false");

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsBatchUnsampledSpanExportProcessor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsBatchUnsampledSpanExportProcessor.cs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsAttributeKeys;
+
+internal class AwsBatchUnsampledSpanExportProcessor : BatchExportProcessor<Activity>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AwsBatchUnsampledSpanExportProcessor"/> class.
+    /// </summary>
+    /// <param name="exporter"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='exporter']"/></param>
+    /// <param name="maxQueueSize"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='maxQueueSize']"/></param>
+    /// <param name="scheduledDelayMilliseconds"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='scheduledDelayMilliseconds']"/></param>
+    /// <param name="exporterTimeoutMilliseconds"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='exporterTimeoutMilliseconds']"/></param>
+    /// <param name="maxExportBatchSize"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='maxExportBatchSize']"/></param>
+    public AwsBatchUnsampledSpanExportProcessor(BaseExporter<Activity> exporter, int maxQueueSize = 2048, int scheduledDelayMilliseconds = 5000, int exporterTimeoutMilliseconds = 30000, int maxExportBatchSize = 512)
+        : base(exporter, maxQueueSize, scheduledDelayMilliseconds, exporterTimeoutMilliseconds, maxExportBatchSize)
+    {
+    }
+
+    /// <inheritdoc />
+    /// TODO: There is an OTEL discussion to add BeforeEnd to allow us to write to spans. Below is a hack and goes
+    /// against the otel specs (not to edit span in OnEnd) but is required for the time being.
+    /// Add BeforeEnd to have a callback where the span is still writeable open-telemetry/opentelemetry-specification#1089
+    /// https://github.com/open-telemetry/opentelemetry-specification/issues/1089
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onendspan
+    public override void OnEnd(Activity data)
+    {
+        // q: looks like on start just adds attribute to activity. Why not add it on end?
+        // ans: main answer is because its out of spec to edit an activity on end.
+        if (!data.Recorded)
+        {
+            data.SetTag(AttributeAWSTraceFlagSampled, "false");
+        }
+
+        // simply put, we only need to call the export function and it will do everything for us
+        // We don't need to check on sampled or not because the original implementation only calls
+        // export on sampled data but this one will call it on everything.
+        this.OnExport(data);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -59,6 +59,7 @@ public class Plugin
     private static readonly string? OtelExporterOtlpEndpoint = System.Environment.GetEnvironmentVariable(OtelExporterOtlpEndpointConfig);
 
     private static readonly string FormatOtelSampledTracesBinaryPrefix = "T1S";
+    private static readonly string FormatOtelUnSampledTracesBinaryPrefix = "T1U";
 
     private static readonly int LambdaSpanExportBatchSize = 10;
 
@@ -107,9 +108,13 @@ public class Plugin
             {
                 Resource processResource = tracerProvider.GetResource();
 
-                var spanExporter = new OtlpUdpExporter(processResource, AwsXrayDaemonAddress, FormatOtelSampledTracesBinaryPrefix);
+                // UDP exporter for sampled spans
+                var sampledSpanExporter = new OtlpUdpExporter(processResource, AwsXrayDaemonAddress, FormatOtelSampledTracesBinaryPrefix);
+                tracerProvider.AddProcessor(new BatchActivityExportProcessor(exporter: sampledSpanExporter, maxExportBatchSize: LambdaSpanExportBatchSize));
 
-                tracerProvider.AddProcessor(new AwsBatchUnsampledSpanExportProcessor(exporter: spanExporter, maxExportBatchSize: LambdaSpanExportBatchSize));
+                // UDP exporter for unsampled spans
+                var unsampledSpanExporter = new OtlpUdpExporter(processResource, AwsXrayDaemonAddress, FormatOtelUnSampledTracesBinaryPrefix);
+                tracerProvider.AddProcessor(new AwsBatchUnsampledSpanExportProcessor(exporter: unsampledSpanExporter, maxExportBatchSize: LambdaSpanExportBatchSize));
             }
 
             // Disable Application Metrics for Lambda environment

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsBatchUnsampledSpanExportProcessorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsBatchUnsampledSpanExportProcessorTest.cs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Reflection;
+using Moq;
+using OpenTelemetry;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsAttributeKeys;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
+
+/// <summary>
+/// AwsBatchUnsampledSpanExportProcessor test class
+/// </summary>
+public class AwsBatchUnsampledSpanExportProcessorTest
+{
+    /// <summary>
+    /// Unit test to check sampled activity is processed
+    /// and that AttributeAWSTraceFlagSampled is not set at all.
+    /// </summary>
+    [Fact]
+    public void CheckThatSampledActivityIsProcessed()
+    {
+        var exporter = new Mock<BaseExporter<Activity>>();
+        using var processor = new AwsBatchUnsampledSpanExportProcessor(
+            exporter.Object,
+            maxQueueSize: 1,
+            maxExportBatchSize: 1);
+
+        using var activity = new Activity("start")
+        {
+            ActivityTraceFlags = ActivityTraceFlags.Recorded,
+        };
+
+        processor.OnEnd(activity);
+        processor.Shutdown();
+
+        Assert.Null(activity.GetTagItem(AttributeAWSTraceFlagSampled));
+
+        PropertyInfo? processedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("ProcessedCount", BindingFlags.NonPublic | BindingFlags.Instance);
+        var processedCount = processedCountInfo?.GetValue(processor);
+        if (processedCount != null)
+        {
+            Assert.Equal(1, (long)processedCount);
+        }
+
+        PropertyInfo? receivedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("ReceivedCount", BindingFlags.NonPublic | BindingFlags.Instance);
+        var receivedCount = receivedCountInfo?.GetValue(processor);
+        if (receivedCount != null)
+        {
+            Assert.Equal(1, (long)receivedCount);
+        }
+
+        PropertyInfo? droppedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("DroppedCount", BindingFlags.NonPublic | BindingFlags.Instance);
+        var droppedCount = droppedCountInfo?.GetValue(processor);
+        if (droppedCount != null)
+        {
+            Assert.Equal(0, (long)droppedCount);
+        }
+    }
+
+    /// <summary>
+    /// Unit test to check unsampled activity is processed and not dropped
+    /// and that AttributeAWSTraceFlagSampled is also set to false.
+    /// </summary>
+    [Fact]
+    public void CheckThatUnSampledActivityIsProcessed()
+    {
+        var exporter = new Mock<BaseExporter<Activity>>();
+        using var processor = new AwsBatchUnsampledSpanExportProcessor(
+            exporter.Object,
+            maxQueueSize: 1,
+            maxExportBatchSize: 1);
+
+        using var activity = new Activity("start")
+        {
+            ActivityTraceFlags = ActivityTraceFlags.None,
+        };
+
+        processor.OnEnd(activity);
+        processor.Shutdown();
+
+        Assert.Equal("false", activity.GetTagItem(AttributeAWSTraceFlagSampled));
+
+        PropertyInfo? processedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("ProcessedCount", BindingFlags.NonPublic | BindingFlags.Instance);
+        var processedCount = processedCountInfo?.GetValue(processor);
+        if (processedCount != null)
+        {
+            Assert.Equal(1, (long)processedCount);
+        }
+
+        PropertyInfo? receivedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("ReceivedCount", BindingFlags.NonPublic | BindingFlags.Instance);
+        var receivedCount = receivedCountInfo?.GetValue(processor);
+        if (receivedCount != null)
+        {
+            Assert.Equal(1, (long)receivedCount);
+        }
+
+        PropertyInfo? droppedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("DroppedCount", BindingFlags.NonPublic | BindingFlags.Instance);
+        var droppedCount = droppedCountInfo?.GetValue(processor);
+        if (droppedCount != null)
+        {
+            Assert.Equal(0, (long)droppedCount);
+        }
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsBatchUnsampledSpanExportProcessorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsBatchUnsampledSpanExportProcessorTest.cs
@@ -19,7 +19,7 @@ public class AwsBatchUnsampledSpanExportProcessorTest
     /// and that AttributeAWSTraceFlagSampled is not set at all.
     /// </summary>
     [Fact]
-    public void CheckThatSampledActivityIsProcessed()
+    public void CheckThatSampledActivityIsNotProcessed()
     {
         var exporter = new Mock<BaseExporter<Activity>>();
         using var processor = new AwsBatchUnsampledSpanExportProcessor(
@@ -41,14 +41,14 @@ public class AwsBatchUnsampledSpanExportProcessorTest
         var processedCount = processedCountInfo?.GetValue(processor);
         if (processedCount != null)
         {
-            Assert.Equal(1, (long)processedCount);
+            Assert.Equal(0, (long)processedCount);
         }
 
         PropertyInfo? receivedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("ReceivedCount", BindingFlags.NonPublic | BindingFlags.Instance);
         var receivedCount = receivedCountInfo?.GetValue(processor);
         if (receivedCount != null)
         {
-            Assert.Equal(1, (long)receivedCount);
+            Assert.Equal(0, (long)receivedCount);
         }
 
         PropertyInfo? droppedCountInfo = typeof(BatchExportProcessor<Activity>).GetProperty("DroppedCount", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
*Description of changes:*

AwsBatchUnsampledSpanExportProcessor class that functions similar to BatchActivityExportProcessor having the same input parameters and the same default values. However, the difference is that BatchActivityExportProcessor only exports sampled (or recorded) activities while AwsBatchUnsampledSpanExportProcessor sets the AttributeAWSTraceFlagSampled to false if activity is not sampled and exports unsampled spans only. As a result, there are two udp exporters added, one wrapped with `BatchActivityExportProcessor` and signal prefix = `T1S` and the other wrapped with `AwsBatchUnsampledSpanExportProcessor` and sends data with signal prefix = `T1U`

*Testing:*
Tested by adding unit tests to verify that both sampled and unsampled spans are being exported. Also tested by merging this to the lambda layer code and verified that unsampled spans are also exported an that the `aws.trace.flag.sampled` attribute is set to false. 

```
{
                        "id": "f3a34280b9417bd8",
                        "name": "S3",
                        "start_time": 1731527234.2218466,
                        "end_time": 1731527234.2937539,
                        "http": {
                            "response": {
                                "status": 200,
                                "content_length": 0
                            }
                        },
                        "aws": {
                            "span.kind": "CLIENT",
                            "service": "S3",
                            "trace.flag.sampled": "false",
                            "requestId": "NJV4KM0WGGHCTGRA",
                            "region": "us-east-1",
                            "operation": "ListBuckets"
                        },
                        "annotations": {
                            "aws.local.service": "SimpleLambdaFunction",
                            "span.name": "S3.ListBuckets",
                            "aws.local.operation": "SimpleLambdaFunction",
                            "span.kind": "CLIENT",
                            "aws.remote.service": "AWS::S3",
                            "aws.remote.operation": "ListBuckets",
                            "aws.local.environment": "lambda:default"
                        },
                        "metadata": {
                            "telemetry.distro.version": "1.4.0.dev0-aws",
                            "rpc.service": "S3",
                            "process.runtime.version": "8.0.8",
                            "os.type": "linux",
                            "process.pid": 2,
                            "os.version": "2023",
                            "telemetry.sdk.name": "opentelemetry",
                            "process.owner": "sbx_user1051",
                            "telemetry.sdk.language": "dotnet",
                            "process.runtime.name": ".NET",
                            "os.description": "Amazon Linux 2023.5.20240903",
                            "rpc.method": "ListBuckets",
                            "os.name": "Amazon Linux",
                            "host.name": "169",
                            "telemetry.sdk.version": "1.9.0",
                            "service.name": "SimpleLambdaFunction",
                            "cloud.region": "us-east-1",
                            "faas.name": "SimpleLambdaFunction",
                            "telemetry.distro.name": "aws-otel-dotnet-instrumentation",
                            "rpc.system": "aws-api",
                            "http.status_code": 200,
                            "cloud.provider": "aws",
                            "http.response_content_length": 0,
                            "faas.instance": "2024/11/13/[$LATEST]17c8d5b7bc8441158899542e438c5596",
                            "os.build_id": "5.10.227-239.884.amzn2.x86_64",
                            "faas.version": "$LATEST",
                            "process.runtime.description": ".NET 8.0.8",
                            "PlatformType": "AWS::Lambda"
                        },
                        "namespace": "aws"
                    },
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

