### PR TITLE
Added git commit SHA to image build for staging

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -59,6 +59,8 @@ jobs:
 
   upload-main-build-image:
     runs-on: ${{ matrix.os }}
+    outputs: 
+      short_sha: ${{ steps.short_sha.outputs.SHORT_SHA }}
     continue-on-error: true
     strategy:
       matrix:
@@ -67,7 +69,13 @@ jobs:
           - os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        
+      - name: Get Short SHA
+        id: short_sha
+        run: |
+          shortsha="$(git rev-parse --short HEAD)"
+          echo "SHORT_SHA=$shortsha" >> $GITHUB_OUTPUT
+        shell: bash
+  
       - name: Configure AWS credentials for private ECR
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -108,14 +116,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -e
-          docker build -t ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-linux-amd64 -f ./Dockerfile.linux .
-          docker push ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-linux-amd64
+          docker build -t ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-linux-amd64-${{ steps.short_sha.outputs.SHORT_SHA }} -f ./Dockerfile.linux .
+          docker push ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-linux-amd64-${{ steps.short_sha.outputs.SHORT_SHA }}
       
       - name: Build Windows container
         if: runner.os == 'Windows'
         run: |
-          docker build -t ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-windows2022 -f ./Dockerfile.windows2022 .
-          docker push ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-windows2022
+          docker build -t ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-windows2022-${{ steps.short_sha.outputs.SHORT_SHA }} -f ./Dockerfile.windows2022 .
+          docker push ${{ secrets.RELEASE_STAIGNG_REPO }}:staging-windows2022-${{ steps.short_sha.outputs.SHORT_SHA }}
         shell: powershell
 
   dotnet-ec2-default-test:
@@ -141,7 +149,7 @@ jobs:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-eks-test.yml@main
     secrets: inherit
     with:
-      adot-image-name: ${{ inputs.adot-linux-image-name }}
+      adot-image-name: ${{ inputs.adot-linux-image-name }}-${{ needs.upload-main-build-image.outputs.short_sha }}
       aws-region: us-east-1
       test-cluster-name: 'e2e-dotnet-adot-test'
       caller-workflow-name: 'main-build'
@@ -151,7 +159,7 @@ jobs:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-eks-windows-test.yml@main
     secrets: inherit
     with:
-      adot-image-name: ${{ inputs.adot-windows-image-name }}
+      adot-image-name: ${{ inputs.adot-windows-image-name }}-${{ needs.upload-main-build-image.outputs.short_sha }}
       aws-region: us-east-1
       test-cluster-name: 'eks-windows-manual'
       caller-workflow-name: 'main-build'


### PR DESCRIPTION
*Description of changes:*
While working on fixing E2E tests, found that there are cases in EKS tests where the incorrect ECR image SHA is being used. Instead of using the latest one, it's using an older version. In this case, it could be using images which aren't from the latest changes. This change appends the git commit hash at the end so that each image is unique. 

*Tested:*
While running E2E tests, updated the branch temporarily to be part of the main_build workflow. Previously, both linux and windows eks tests were using an older hash. With this change, they are using the correct one. Example run can be found here: https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/11963044474

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

