### PR TITLE
Add Application Signals runtime metrics with feature disabled

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
@@ -51,10 +51,6 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
     // Special DEPENDENCY attribute value if GRAPHQL_OPERATION_TYPE attribute key is present.
     private static readonly string GraphQL = "graphql";
 
-    // As per https://opentelemetry.io/docs/specs/semconv/resource/#service
-    // If service name is not specified, SDK defaults the service name starting with unknown_service
-    private static readonly string OtelUnknownServicePrefix = "unknown_service";
-
     /// <inheritdoc/>
     public virtual Dictionary<string, ActivityTagsCollection> GenerateMetricAttributeMapFromSpan(Activity span, Resource resource)
     {
@@ -100,10 +96,10 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
     private static void SetService(Resource resource, Activity span, ActivityTagsCollection attributes)
 #pragma warning restore SA1204 // Static elements should appear before instance elements
     {
-        string? service = (string?)resource.Attributes.FirstOrDefault(attribute => attribute.Key == AttributeServiceName).Value;
+        string? service = (string?)resource.Attributes.FirstOrDefault(attribute => attribute.Key == AttributeAWSLocalService).Value;
 
         // In practice the service name is never null, but we can be defensive here.
-        if (service == null || service.StartsWith(OtelUnknownServicePrefix))
+        if (service == null)
         {
             LogUnknownAttribute(AttributeAWSLocalService, span);
             service = UnknownService;

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -41,6 +41,8 @@ public class Plugin
     private static readonly ILoggerFactory Factory = LoggerFactory.Create(builder => builder.AddProvider(new ConsoleLoggerProvider()));
     private static readonly ILogger Logger = Factory.CreateLogger<Plugin>();
     private static readonly string ApplicationSignalsExporterEndpointConfig = "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT";
+    private static readonly string ApplicationSignalsRuntimeEnabledConfig = "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED";
+    private static readonly string MetricExporterConfig = "OTEL_METRICS_EXPORTER";
     private static readonly string MetricExportIntervalConfig = "OTEL_METRIC_EXPORT_INTERVAL";
     private static readonly int DefaultMetricExportInterval = 60000;
     private static readonly string DefaultProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
@@ -59,6 +61,7 @@ public class Plugin
 
     private static readonly string FormatOtelSampledTracesBinaryPrefix = "T1S";
     private static readonly string FormatOtelUnSampledTracesBinaryPrefix = "T1U";
+    private static readonly string RuntimeMetricMeterName = "OpenTelemetry.Instrumentation.Runtime";
 
     private static readonly int LambdaSpanExportBatchSize = 10;
 
@@ -119,27 +122,9 @@ public class Plugin
             // Disable Application Metrics for Lambda environment
             if (!AwsSpanProcessingUtil.IsLambdaEnvironment())
             {
-                string? intervalConfigString = System.Environment.GetEnvironmentVariable(MetricExportIntervalConfig);
-                int exportInterval = DefaultMetricExportInterval;
-                try
-                {
-                    int parsedExportInterval = Convert.ToInt32(intervalConfigString);
-                    exportInterval = parsedExportInterval != 0 ? parsedExportInterval : DefaultMetricExportInterval;
-                }
-                catch (Exception)
-                {
-                    Logger.Log(LogLevel.Trace, "Could not convert OTEL_METRIC_EXPORT_INTERVAL to integer. Using default value 60000.");
-                }
-
-                if (exportInterval.CompareTo(DefaultMetricExportInterval) > 0)
-                {
-                    exportInterval = DefaultMetricExportInterval;
-                    Logger.Log(LogLevel.Information, "AWS Application Signals metrics export interval capped to {0}", exportInterval);
-                }
-
                 // https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#enable-metric-exporter
                 // for setting the temporatityPref.
-                var metricReader = new PeriodicExportingMetricReader(this.ApplicationSignalsExporterProvider(), exportInterval)
+                var metricReader = new PeriodicExportingMetricReader(this.CreateApplicationSignalsMetricExporter(), GetMetricExportInterval())
                 {
                     TemporalityPreference = MetricReaderTemporalityPreference.Delta,
                 };
@@ -225,6 +210,40 @@ public class Plugin
                 builder.SetSampler(alwaysOnSampler);
             }
         }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// // To configure metrics SDK after Auto Instrumentation configured SDK
+    /// </summary>
+    /// <param name="builder">The metric provider builder</param>
+    /// <returns>The configured metric provider builder</returns>
+    public MeterProviderBuilder AfterConfigureMeterProvider(MeterProviderBuilder builder)
+    {
+        if (!this.IsApplicationSignalsRuntimeEnabled())
+        {
+            return builder;
+        }
+
+        var exporters = System.Environment.GetEnvironmentVariable(MetricExporterConfig);
+        if (!string.IsNullOrEmpty(exporters) && exporters.Contains("none"))
+        {
+            Logger.Log(LogLevel.Information, "Install runtime metric filter in metrics collection.");
+            builder.AddView(instrument => instrument.Meter.Name == RuntimeMetricMeterName
+                ? null
+                : MetricStreamConfiguration.Drop);
+        }
+
+        var runtimeScopeName = new HashSet<string>() { RuntimeMetricMeterName };
+        var metricReader = new PeriodicExportingMetricReader(
+            this.CreateScopeBasedOtlpMetricExporter(runtimeScopeName), GetMetricExportInterval())
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
+
+        builder.AddReader(metricReader);
+        Logger.Log(LogLevel.Information, "AWS Application Signals runtime metrics enabled.");
 
         return builder;
     }
@@ -401,9 +420,22 @@ public class Plugin
         return System.Environment.GetEnvironmentVariable(ApplicationSignalsEnabledConfig) == "true";
     }
 
+    private bool IsApplicationSignalsRuntimeEnabled()
+    {
+        return false;
+    }
+
     private ResourceBuilder ResourceBuilderCustomizer(ResourceBuilder builder)
     {
         builder.AddAttributes(DistroAttributes);
+        var resource = builder.Build();
+        var serviceName = (string?)resource.Attributes.FirstOrDefault(attr => attr.Key == ResourceSemanticConventions.AttributeServiceName).Value;
+        if (string.IsNullOrEmpty(serviceName) || serviceName.StartsWith("unknown_service"))
+        {
+            serviceName = "UnknownService";
+        }
+
+        builder.AddAttributes(new Dictionary<string, object> { { "aws.local.service", serviceName } });
 
         // ResourceDetectors are enabled by default. Adding config to be able to disable during local testing
         var resourceDetectorsEnabled = System.Environment.GetEnvironmentVariable(ResourceDetectorEnableConfig) ?? "true";
@@ -428,37 +460,71 @@ public class Plugin
         return builder;
     }
 
-    private OtlpMetricExporter ApplicationSignalsExporterProvider()
+    private OtlpMetricExporter CreateApplicationSignalsMetricExporter()
     {
         var options = new OtlpExporterOptions();
+        ConfigureOtlpExporterOptions(options);
+        return new OtlpMetricExporter(options);
+    }
 
-        string? applicationSignalsEndpoint = System.Environment.GetEnvironmentVariable(ApplicationSignalsExporterEndpointConfig);
-        string? protocolString = System.Environment.GetEnvironmentVariable(DefaultProtocolEnvVarName) ?? "http/protobuf";
+    private ScopeBasedOtlpMetricExporter CreateScopeBasedOtlpMetricExporter(HashSet<string> registeredScopeNames)
+    {
+        var options = new ScopeBasedOtlpMetricExporter.ScopeBasedOtlpExporterOptions();
+        ConfigureOtlpExporterOptions(options);
+        options.RegisteredScopeNames = registeredScopeNames;
+        return new ScopeBasedOtlpMetricExporter(options);
+    }
+
+    private static int GetMetricExportInterval()
+    {
+        var intervalConfigString = System.Environment.GetEnvironmentVariable(MetricExportIntervalConfig);
+        var exportInterval = DefaultMetricExportInterval;
+        try
+        {
+            var parsedExportInterval = Convert.ToInt32(intervalConfigString);
+            exportInterval = parsedExportInterval != 0 ? parsedExportInterval : DefaultMetricExportInterval;
+        }
+        catch (Exception)
+        {
+            Logger.Log(LogLevel.Trace, "Could not convert OTEL_METRIC_EXPORT_INTERVAL to integer. Using default value 60000.");
+        }
+
+        if (exportInterval.CompareTo(DefaultMetricExportInterval) > 0)
+        {
+            exportInterval = DefaultMetricExportInterval;
+            Logger.Log(LogLevel.Information, "AWS Application Signals metrics export interval capped to {0}", exportInterval);
+        }
+
+        return exportInterval;
+    }
+
+    private static void ConfigureOtlpExporterOptions(OtlpExporterOptions options)
+    {
+        var applicationSignalsEndpoint = System.Environment.GetEnvironmentVariable(ApplicationSignalsExporterEndpointConfig);
+        var protocolString = System.Environment.GetEnvironmentVariable(DefaultProtocolEnvVarName) ?? "http/protobuf";
         OtlpExportProtocol protocol;
-        if (protocolString == "http/protobuf")
+
+        switch (protocolString)
         {
-            applicationSignalsEndpoint = applicationSignalsEndpoint ?? "http://localhost:4316/v1/metrics";
-            protocol = OtlpExportProtocol.HttpProtobuf;
-        }
-        else if (protocolString == "grpc")
-        {
-            applicationSignalsEndpoint = applicationSignalsEndpoint ?? "http://localhost:4315";
-            protocol = OtlpExportProtocol.Grpc;
-        }
-        else
-        {
-            throw new NotSupportedException("Unsupported AWS Application Signals export protocol: " + protocolString);
+            case "http/protobuf":
+                applicationSignalsEndpoint = applicationSignalsEndpoint ?? "http://localhost:4316/v1/metrics";
+                protocol = OtlpExportProtocol.HttpProtobuf;
+                break;
+            case "grpc":
+                applicationSignalsEndpoint = applicationSignalsEndpoint ?? "http://localhost:4315";
+                protocol = OtlpExportProtocol.Grpc;
+                break;
+            default:
+                throw new NotSupportedException("Unsupported AWS Application Signals export protocol: " + protocolString);
         }
 
         options.Endpoint = new Uri(applicationSignalsEndpoint);
         options.Protocol = protocol;
 
         Logger.Log(
-          LogLevel.Debug, "AWS Application Signals export protocol: %{0}", options.Protocol);
+            LogLevel.Debug, "AWS Application Signals export protocol: %{0}", options.Protocol);
         Logger.Log(
-          LogLevel.Debug, "AWS Application Signals export endpoint: %{0}", options.Endpoint);
-
-        return new OtlpMetricExporter(options);
+            LogLevel.Debug, "AWS Application Signals export endpoint: %{0}", options.Endpoint);
     }
 
     private bool HasCustomTracesEndpoint()

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/ScopeBasedOtlpMetricExporter.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/ScopeBasedOtlpMetricExporter.cs
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.AutoInstrumentation.Logging;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// A custom metric exporter that extends <see cref="OtlpMetricExporter"/>.
+/// Exports metrics only for a specific instrumentation scope, filtering based on
+/// the configured scope name. This allows selective metric exporting to the OTLP endpoint,
+/// limiting exports to metrics that match the specified scope.
+/// </summary>
+public class ScopeBasedOtlpMetricExporter : OtlpMetricExporter
+{
+    private static readonly ILoggerFactory Factory = LoggerFactory.Create(builder => builder.AddProvider(new ConsoleLoggerProvider()));
+    private static readonly ILogger Logger = Factory.CreateLogger<ScopeBasedOtlpMetricExporter>();
+
+    private readonly HashSet<string> registeredScopedNames;
+    private readonly Func<Batch<Metric>, ExportResult> exportHandler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScopeBasedOtlpMetricExporter"/> class.
+    /// </summary>
+    /// <param name="options">Configuration options for the exporter.</param>
+    public ScopeBasedOtlpMetricExporter(ScopeBasedOtlpExporterOptions options)
+        : base(options)
+    {
+        this.registeredScopedNames = options.RegisteredScopeNames ?? new HashSet<string>();
+        this.exportHandler = batch => base.Export(batch);
+    }
+
+    internal ScopeBasedOtlpMetricExporter(
+        ScopeBasedOtlpExporterOptions options,
+        Func<Batch<Metric>, ExportResult> exportHandler)
+        : base(options)
+    {
+        this.registeredScopedNames = options.RegisteredScopeNames ?? new HashSet<string>();
+        this.exportHandler = exportHandler;
+    }
+
+    /// <inheritdoc />
+    public override ExportResult Export(in Batch<Metric> metrics)
+    {
+        var exportingMetrics = new List<Metric>();
+        foreach (var metric in metrics)
+        {
+            if (this.registeredScopedNames.Contains(metric.MeterName))
+            {
+                exportingMetrics.Add(metric);
+            }
+        }
+
+        if (exportingMetrics.Count == 0)
+        {
+            Logger.Log(LogLevel.Debug, "No metrics to export.");
+            return ExportResult.Success;
+        }
+
+        return this.exportHandler.Invoke(new Batch<Metric>(exportingMetrics.ToArray(), exportingMetrics.Count));
+    }
+
+    /// <summary>
+    /// Scope based OTLP exporter options.
+    /// </summary>
+    public class ScopeBasedOtlpExporterOptions : OtlpExporterOptions
+    {
+        /// <summary>
+        /// Gets or sets registered meter names whose metrics will be reserved.
+        /// </summary>
+        public HashSet<string>? RegisteredScopeNames { get; set; }
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsMetricAttributesGeneratorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsMetricAttributesGeneratorTest.cs
@@ -1181,6 +1181,7 @@ public class AwsMetricAttributesGeneratorTest
         List<KeyValuePair<string, object?>> resourceAttributes = new List<KeyValuePair<string, object?>>
         {
             new (AutoInstrumentation.AwsMetricAttributeGenerator.AttributeServiceName, this.serviceNameValue),
+            new (AwsAttributeKeys.AttributeAWSLocalService, this.serviceNameValue),
         };
         this.resource = new Resource(resourceAttributes);
     }

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/ScopeBasedOtlpMetricExporterTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/ScopeBasedOtlpMetricExporterTest.cs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Metrics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
+
+/// <summary>
+/// ScopeBasedOtlpMetricExporter test class
+/// </summary>
+public class ScopeBasedOtlpMetricExporterTest
+{
+    private readonly string retainedScopeName = "test.retained";
+    private readonly string droppedScopeName = "test.drop";
+
+    [Fact]
+    public void TestExport()
+    {
+        var opts = new ScopeBasedOtlpMetricExporter.ScopeBasedOtlpExporterOptions()
+        {
+            RegisteredScopeNames = new HashSet<string>() { this.retainedScopeName },
+        };
+
+        var exportAssert = new ExportAssert(6, this.retainedScopeName);
+        var exporter = new ScopeBasedOtlpMetricExporter(opts, (batch) =>
+        {
+            exportAssert.Verify(batch);
+            return ExportResult.Success;
+        });
+
+        var sdk = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(this.retainedScopeName)
+            .AddMeter(this.droppedScopeName)
+            .AddReader(new BaseExportingMetricReader(exporter))
+            .Build();
+
+        this.GenerateMetrics(6, 12);
+
+        sdk.Dispose();
+        Thread.Sleep(10);
+
+        Assert.True(exportAssert.Success);
+    }
+
+    private void GenerateMetrics(int retained, int dropped)
+    {
+        var meter = new Meter(this.retainedScopeName);
+        for (var i = 0; i < retained; i++)
+        {
+            var counter = meter.CreateCounter<int>("test.counter." + i);
+            counter.Add(1);
+        }
+
+        meter = new Meter(this.droppedScopeName);
+        for (var i = 0; i < dropped; i++)
+        {
+            var counter = meter.CreateCounter<int>("test.counter." + i);
+            counter.Add(1);
+        }
+    }
+
+    private class ExportAssert
+    {
+        private readonly int expectedCount;
+        private readonly string registeredMeterName;
+
+        internal ExportAssert(int expectedCount, string registeredMeterName)
+        {
+            this.expectedCount = expectedCount;
+            this.registeredMeterName = registeredMeterName;
+        }
+
+        public bool Success { get; private set; }
+
+        public void Verify(Batch<Metric> batch)
+        {
+            this.Success = true;
+            if (batch.Count != this.expectedCount)
+            {
+                this.Success = false;
+            }
+
+            foreach (var m in batch)
+            {
+                if (m.MeterName != this.registeredMeterName)
+                {
+                    this.Success = false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Bootstrap .NET plugin with the ability to collect runtime metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

