### PR TITLE
Fixed dotnet lambda layer E2E to run against main.

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -199,7 +199,7 @@ jobs:
         
   dotnet-lambda-test:
     needs: [ build-lambda-staging-sample-app ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-lambda-test.yml@dotnetLambdaE2E
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-lambda-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1


### PR DESCRIPTION
*Description of changes:*
Fixed dotnet lambda layer E2E to run against main. This revert was missed before merging the Lambda Layer E2E as I was testing against another branch until the changes were merged to main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

