### PR TITLE
Updated upload-artifact action to v4

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -49,28 +49,28 @@ jobs:
 
       - name: Upload Artifact on X64 Linux
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
       
       - name: Upload bash installation script
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-otel-dotnet-install.sh
           path: bin/InstallationScripts/aws-otel-dotnet-install.sh
 
       - name: Upload psm1 installation script
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: AWS.Otel.DotNet.Auto.psm1
           path: bin/InstallationScripts/AWS.Otel.DotNet.Auto.psm1
 
       - name: Upload Artifact on Windows
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
@@ -91,7 +91,7 @@ jobs:
             /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
 
       - name: Upload Artifact on MUSL X64 Linux
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
@@ -113,7 +113,7 @@ jobs:
         run: dotnet test
 
       - name: Upload Artifact on arm64 Linux
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
@@ -134,7 +134,7 @@ jobs:
             /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
 
       - name: Upload Artifact on MUSL arm64 Linux
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -354,7 +354,7 @@ jobs:
           -o .\Deployment\nuget-packages
 
       - name: Upload nugets to this GitHub Action run as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuget-packages.zip
           path: Deployment/nuget-packages/

--- a/.github/workflows/release_lambda.yml
+++ b/.github/workflows/release_lambda.yml
@@ -125,7 +125,7 @@ jobs:
             --action lambda:GetLayerVersion
       - name: upload layer arn artifact
         if: ${{ success() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
@@ -180,7 +180,7 @@ jobs:
           terraform fmt layer.tf
           cat layer.tf
       - name: upload layer tf file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: layer.tf
           path: layer.tf


### PR DESCRIPTION
*Description of changes:*
Builds were automatically failing because we are using v3 of the checkout action. This updates it to v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

