### PR TITLE
Updated download-artifact action to v4

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -44,11 +44,11 @@ jobs:
           role-external-id: ApplicationSignalsDotnet
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.ec2-default-image-name }}
       
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.ec2-windows-image-name }}
 
@@ -89,14 +89,14 @@ jobs:
         
       - name: Download Linux x64 Artifact
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: ./artifacts/linux/x64
           
       - name: Download Windows Artifact
         if: runner.os == 'Windows'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: ./artifacts/windows

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -40,43 +40,43 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Linux x64 Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: ./artifacts/linux/x64
 
       - name: Download Linux arm64 Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
           path: ./artifacts/linux/arm64
 
       - name: Download Windows Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: ./artifacts/windows
 
       - name: Download Linux X64 MUSL Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: ./artifacts/linux/x64-musl
       
       - name: Download Linux arm64 MUSL Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: ./artifacts/linux/arm64-musl
 
       - name: Download bash installation script
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-otel-dotnet-install.sh
           path: ./installationScripts
       
       - name: Download psm1 installation script
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: AWS.Otel.DotNet.Auto.psm1
           path: ./installationScripts
@@ -152,28 +152,28 @@ jobs:
 
       - name: Download Linux x64 Artifact
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: ./artifacts/linux/x64
 
       - name: Download Linux X64 MUSL Artifact
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: ./artifacts/linux/x64-musl
 
       - name: Download Linux arm64 Artifact
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
           path: ./artifacts/linux/arm64
 
       - name: Download Linux arm64 MUSL Artifact
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: ./artifacts/linux/arm64-musl
@@ -189,7 +189,7 @@ jobs:
 
       - name: Download Windows Artifact
         if: runner.os == 'Windows'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: ./artifacts/windows

--- a/.github/workflows/release_lambda.yml
+++ b/.github/workflows/release_lambda.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           echo BUCKET_NAME=dotnet-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
       - name: Download Linux x64 Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
       - name: publish
@@ -141,7 +141,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v2
       - name: download layerARNs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}


### PR DESCRIPTION
*Description of changes:*
Follow up to this [PR](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/commit/9c8b40c2241d0b8af4ec5f0bba30a6b13125f25d) but this time updating the download-artifact action to v4. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

