### PR TITLE
Updated the E2E Windows Cluster Name

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -175,7 +175,7 @@ jobs:
     with:
       adot-image-name: ${{ inputs.adot-windows-image-name }}-${{ needs.upload-main-build-image.outputs.short_sha }}
       aws-region: us-east-1
-      test-cluster-name: 'eks-windows-manual'
+      test-cluster-name: 'e2e-dotnet-windows-canary-test'
       caller-workflow-name: 'main-build'
         
   build-lambda-staging-sample-app:


### PR DESCRIPTION
*Description of changes:*
Updated the E2E Windows Cluster Name. The cluster name was changed in this PR: https://github.com/aws-observability/aws-application-signals-test-framework/pull/354

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

