### PR TITLE
chore: add an argument to enable .net sample app running on Mac conta…

### DIFF
--- a/sample-applications/integration-test-app/Dockerfile
+++ b/sample-applications/integration-test-app/Dockerfile
@@ -1,7 +1,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 COPY . ./
-RUN dotnet publish integration-test-app/*.csproj -c Release -o out
+ARG TARGET_DOTNET_RUNTIME=linux-x64
+RUN dotnet publish integration-test-app/*.csproj -c Release -o out --runtime ${TARGET_DOTNET_RUNTIME} --self-contained true
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app

--- a/sample-applications/integration-test-app/build-and-start-application.sh
+++ b/sample-applications/integration-test-app/build-and-start-application.sh
@@ -17,7 +17,8 @@ rm -rf ./OpenTelemetryDistribution
 cp -r ../../OpenTelemetryDistribution .
 check_if_step_failed_and_exit "There was an error moving OpenTelemetryDistribution to the sample app , exiting"
 
-docker build -t aspnetapp .
+# On ARM CPU, set TARGET_DOTNET_RUNTIME=linux-arm64
+docker build --build-arg TARGET_DOTNET_RUNTIME=linux-x64 -t aspnetapp .
 check_if_step_failed_and_exit "There was an error building the docker container, exiting"
 
 docker compose up 


### PR DESCRIPTION
I need to run the testing app on Macbook container to step through the code. Unfortunately, by default it would fail without a hint. 

This PR will add an argument in Dockerfile to enable .net sample app running on Macbook container.

I tested the images on EC2 Linux-x64 and Win-x64. All pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

