### PR TITLE
Moved SerializeSpans and helper methods to separate utils class.

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/OtlpExporterUtils.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/OtlpExporterUtils.cs
@@ -1,0 +1,263 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Reflection;
+using AWS.Distro.OpenTelemetry.AutoInstrumentation.Logging;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
+
+public class OtlpExporterUtils {
+    private static readonly ILoggerFactory Factory = LoggerFactory.Create(builder => builder.AddProvider(new ConsoleLoggerProvider()));
+    private static readonly ILogger Logger = Factory.CreateLogger<OtlpExporterUtils>();
+
+    // The SerializeSpans function builds a ExportTraceServiceRequest object by calling private "ToOtlpSpan" function
+    // using reflection. "ToOtlpSpan" converts an Activity object into an OpenTelemetry.Proto.Trace.V1.Span object.
+    // With the conversion above, the Activity object is converted to an Otel span object to be exported using the
+    // UDP exporter. The "ToOtlpSpan" function can be found here:
+    // https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs#L136
+    public static byte[]? SerializeSpans(Batch<Activity> batch, Resource processResource)
+    {
+        Type? activityExtensionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ActivityExtensions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
+
+        Type? sdkLimitOptionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.SdkLimitOptions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
+
+        if (sdkLimitOptionsType == null)
+        {
+            Logger.LogTrace("SdkLimitOptions Type was not found");
+            return null;
+        }
+
+        MethodInfo? toOtlpSpanMethod = activityExtensionsType?.GetMethod(
+            "ToOtlpSpan",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            null,
+            new[] { typeof(Activity), sdkLimitOptionsType },
+            null);
+
+        var request = new ExportTraceServiceRequest();
+        var sdkLimitOptions = OtlpExporterUtils.GetSdkLimitOptions();
+
+        if (sdkLimitOptions == null)
+        {
+            Logger.LogTrace("SdkLimitOptions Object was not found/created properly using the default parameterless constructor");
+            return null;
+        }
+
+        var otlpResource = OtlpExporterUtils.ToOtlpResource(processResource);
+
+        // Create a ResourceSpans instance to hold the span and the otlpResource
+        ResourceSpans resourceSpans = new ResourceSpans
+        {
+            Resource = otlpResource,
+        };
+        var scopeSpans = new ScopeSpans();
+
+        if (toOtlpSpanMethod != null)
+        {
+            foreach (var activity in batch)
+            {
+                var otlpSpan = toOtlpSpanMethod.Invoke(null, new object[] { activity, sdkLimitOptions });
+
+                // The converters below are required since the the JsonConvert.DeserializeObject doesn't
+                // know how to deserialize a BytesString or SpanKinds from otlp proto json object.
+                var settings = new Newtonsoft.Json.JsonSerializerSettings();
+                settings.Converters.Add(new ByteStringConverter());
+                settings.Converters.Add(new SpanKindConverter());
+                settings.Converters.Add(new StatusCodeConverter());
+
+                // Below is a workaround to casting and works by converting an object into JSON then converting the
+                // JSON string back into the required object type. The reason casting isn't working is because of different
+                // assemblies being used. To use the protobuf library, we need to have a local copy of the protobuf assembly.
+                // Since upstream also has their own copy of the protobuf library, casting is not possible since the complier
+                // is recognizing them as two different types.
+                try
+                {
+                    var otlpSpanJson = otlpSpan?.ToString();
+                    if (otlpSpanJson == null)
+                    {
+                        continue;
+                    }
+
+                    var otlpSpanConverted = JsonConvert.DeserializeObject<Span>(otlpSpanJson, settings);
+                    scopeSpans.Spans.Add(otlpSpanConverted);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Error converting OtlpSpan to/from JSON: {ex.Message}");
+                }
+            }
+
+            resourceSpans.ScopeSpans.Add(scopeSpans);
+            request.ResourceSpans.Add(resourceSpans);
+        }
+        else
+        {
+            Logger.LogTrace("ActivityExtensions.ToOtlpSpan method is not found");
+        }
+
+        return request.ToByteArray();
+    }
+
+    // Function that uses reflection to call ResourceExtensions.ToOtlpResource function.
+    // This functions converts from an OpenTelemetry.Resources.Resource to
+    // OpenTelemetry.Proto.Resource.V1.Resource (protobuf resource to be exported)
+    private static OtlpResource.Resource? ToOtlpResource(Resource processResource)
+    {
+        Type? resourceExtensionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ResourceExtensions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
+
+        if (resourceExtensionsType == null)
+        {
+            Logger.LogTrace("ResourceExtensions Type was not found");
+            return null;
+        }
+
+        MethodInfo? toOtlpResourceMethod = resourceExtensionsType.GetMethod(
+            "ToOtlpResource",
+            BindingFlags.Static | BindingFlags.Public,
+            null,
+            new[] { typeof(Resource) },
+            null);
+
+        if (toOtlpResourceMethod == null)
+        {
+            Logger.LogTrace("ResourceExtensions.ToOtlpResource Method was not found");
+            return null;
+        }
+
+        var otlpResource = toOtlpResourceMethod.Invoke(null, new object[] { processResource });
+
+        if (otlpResource == null)
+        {
+            Logger.LogTrace("OtlpResource object cannot be converted from OpenTelemetry.Resources");
+            return null;
+        }
+
+        // Below is a workaround to casting and works by converting an object into JSON then converting the
+        // JSON string back into the required object type. The reason casting isn't working is because of different
+        // assemblies being used. To use the protobuf library, we need to have a local copy of the protobuf assembly.
+        // Since upstream also has their own copy of the protobuf library, casting is not possible since the complier
+        // is recognizing them as two different types.
+        try
+        {
+            // ToString method from OpenTelemetry.Proto.Resource.V1.Resource already converts the object into
+            // Json using the proper converters.
+            string? otlpResourceJson = otlpResource.ToString();
+            if (otlpResourceJson == null)
+            {
+                Logger.LogTrace("OtlpResource object cannot be converted to JSON");
+                return null;
+            }
+
+            var otlpResourceConverted = JsonConvert.DeserializeObject<OtlpResource.Resource>(otlpResourceJson);
+            return otlpResourceConverted;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Error converting OtlpResource to/from JSON: {ex.Message}");
+            return null;
+        }
+    }
+
+    // Uses reflection to the get the SdkLimitOptions required to invoke the ToOtlpSpan function used in the
+    // SerializeSpans function below. More information about SdkLimitOptions can be found in this link:
+    // https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/SdkLimitOptions.cs#L24
+    private static object? GetSdkLimitOptions()
+    {
+        Type? sdkLimitOptionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.SdkLimitOptions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
+
+        if (sdkLimitOptionsType == null)
+        {
+            Logger.LogTrace("SdkLimitOptions Type was not found");
+            return null;
+        }
+
+        // Create an instance of SdkLimitOptions using the default parameterless constructor
+        object? sdkLimitOptionsInstance = Activator.CreateInstance(sdkLimitOptionsType);
+        return sdkLimitOptionsInstance;
+    }
+}
+
+internal class ByteStringConverter : JsonConverter<ByteString>
+{
+    /// <inheritdoc/>
+    public override ByteString? ReadJson(JsonReader reader, Type objectType, ByteString? existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        var base64String = (string?)reader.Value;
+        return ByteString.FromBase64(base64String);
+    }
+
+    /// <inheritdoc/>
+    public override void WriteJson(JsonWriter writer, ByteString? value, JsonSerializer serializer)
+    {
+        writer.WriteValue(value?.ToBase64());
+    }
+}
+
+internal class SpanKindConverter : JsonConverter<Span.Types.SpanKind>
+{
+    /// <inheritdoc/>
+    public override Span.Types.SpanKind ReadJson(JsonReader reader, Type objectType, Span.Types.SpanKind existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        // Handle the string to enum conversion
+        string? enumString = reader.Value?.ToString();
+
+        // Convert the string representation to the corresponding enum value
+        switch (enumString)
+        {
+            case "SPAN_KIND_CLIENT":
+                return Span.Types.SpanKind.Client;
+            case "SPAN_KIND_SERVER":
+                return Span.Types.SpanKind.Server;
+            case "SPAN_KIND_INTERNAL":
+                return Span.Types.SpanKind.Internal;
+            case "SPAN_KIND_PRODUCER":
+                return Span.Types.SpanKind.Producer;
+            case "SPAN_KIND_CONSUMER":
+                return Span.Types.SpanKind.Consumer;
+            default:
+                throw new JsonSerializationException($"Unknown SpanKind: {enumString}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void WriteJson(JsonWriter writer, Span.Types.SpanKind value, JsonSerializer serializer)
+    {
+        // Write the string representation of the enum
+        writer.WriteValue(value.ToString());
+    }
+}
+
+internal class StatusCodeConverter : JsonConverter<Status.Types.StatusCode>
+{
+    /// <inheritdoc/>
+    public override Status.Types.StatusCode ReadJson(JsonReader reader, Type objectType, Status.Types.StatusCode existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        // Handle the string to enum conversion
+        string? enumString = reader.Value?.ToString();
+
+        // Convert the string representation to the corresponding enum value
+        switch (enumString)
+        {
+            case "STATUS_CODE_UNSET":
+                return Status.Types.StatusCode.Unset;
+            case "STATUS_CODE_OK":
+                return Status.Types.StatusCode.Ok;
+            case "STATUS_CODE_ERROR":
+                return Status.Types.StatusCode.Error;
+            default:
+                throw new JsonSerializationException($"Unknown StatusCode: {enumString}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void WriteJson(JsonWriter writer, Status.Types.StatusCode value, JsonSerializer serializer)
+    {
+        // Write the string representation of the enum
+        writer.WriteValue(value.ToString());
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/OtlpUdpExporter.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/OtlpUdpExporter.cs
@@ -3,17 +3,11 @@
 
 using System.Diagnostics;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Text;
 using AWS.Distro.OpenTelemetry.AutoInstrumentation.Logging;
-using Google.Protobuf;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using OpenTelemetry;
-using OpenTelemetry.Proto.Collector.Trace.V1;
-using OpenTelemetry.Proto.Trace.V1;
 using OpenTelemetry.Resources;
-using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 /// <summary>
 /// OTLP UDP Exporter class. This class is used to build an OtlpUdpExporter to registered as in exporter
@@ -45,7 +39,7 @@ public class OtlpUdpExporter : BaseExporter<Activity>
     /// <inheritdoc/>
     public override ExportResult Export(in Batch<Activity> batch)
     {
-        byte[]? serializedData = this.SerializeSpans(batch);
+        byte[]? serializedData = OtlpExporterUtils.SerializeSpans(batch, this.processResource);
         if (serializedData == null)
         {
             return ExportResult.Failure;
@@ -76,172 +70,6 @@ public class OtlpUdpExporter : BaseExporter<Activity>
             Logger.LogError($"Error shutting down exporter: {ex.Message}");
             return false;
         }
-    }
-
-    // Function that uses reflection to call ResourceExtensions.ToOtlpResource function.
-    // This functions converts from an OpenTelemetry.Resources.Resource to
-    // OpenTelemetry.Proto.Resource.V1.Resource (protobuf resource to be exported)
-    private OtlpResource.Resource? ToOtlpResource(Resource processResource)
-    {
-        Type? resourceExtensionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ResourceExtensions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
-
-        if (resourceExtensionsType == null)
-        {
-            Logger.LogTrace("ResourceExtensions Type was not found");
-            return null;
-        }
-
-        MethodInfo? toOtlpResourceMethod = resourceExtensionsType.GetMethod(
-            "ToOtlpResource",
-            BindingFlags.Static | BindingFlags.Public,
-            null,
-            new[] { typeof(Resource) },
-            null);
-
-        if (toOtlpResourceMethod == null)
-        {
-            Logger.LogTrace("ResourceExtensions.ToOtlpResource Method was not found");
-            return null;
-        }
-
-        var otlpResource = toOtlpResourceMethod.Invoke(null, new object[] { processResource });
-
-        if (otlpResource == null)
-        {
-            Logger.LogTrace("OtlpResource object cannot be converted from OpenTelemetry.Resources");
-            return null;
-        }
-
-        // Below is a workaround to casting and works by converting an object into JSON then converting the
-        // JSON string back into the required object type. The reason casting isn't working is because of different
-        // assemblies being used. To use the protobuf library, we need to have a local copy of the protobuf assembly.
-        // Since upstream also has their own copy of the protobuf library, casting is not possible since the complier
-        // is recognizing them as two different types.
-        try
-        {
-            // ToString method from OpenTelemetry.Proto.Resource.V1.Resource already converts the object into
-            // Json using the proper converters.
-            string? otlpResourceJson = otlpResource.ToString();
-            if (otlpResourceJson == null)
-            {
-                Logger.LogTrace("OtlpResource object cannot be converted to JSON");
-                return null;
-            }
-
-            var otlpResourceConverted = JsonConvert.DeserializeObject<OtlpResource.Resource>(otlpResourceJson);
-            return otlpResourceConverted;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError($"Error converting OtlpResource to/from JSON: {ex.Message}");
-            return null;
-        }
-    }
-
-    // Uses reflection to the get the SdkLimitOptions required to invoke the ToOtlpSpan function used in the
-    // SerializeSpans function below. More information about SdkLimitOptions can be found in this link:
-    // https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/SdkLimitOptions.cs#L24
-    private object? GetSdkLimitOptions()
-    {
-        Type? sdkLimitOptionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.SdkLimitOptions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
-
-        if (sdkLimitOptionsType == null)
-        {
-            Logger.LogTrace("SdkLimitOptions Type was not found");
-            return null;
-        }
-
-        // Create an instance of SdkLimitOptions using the default parameterless constructor
-        object? sdkLimitOptionsInstance = Activator.CreateInstance(sdkLimitOptionsType);
-        return sdkLimitOptionsInstance;
-    }
-
-    // The SerializeSpans function builds a ExportTraceServiceRequest object by calling private "ToOtlpSpan" function
-    // using reflection. "ToOtlpSpan" converts an Activity object into an OpenTelemetry.Proto.Trace.V1.Span object.
-    // With the conversion above, the Activity object is converted to an Otel span object to be exported using the
-    // UDP exporter. The "ToOtlpSpan" function can be found here:
-    // https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs#L136
-    private byte[]? SerializeSpans(Batch<Activity> batch)
-    {
-        Type? activityExtensionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ActivityExtensions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
-
-        Type? sdkLimitOptionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.SdkLimitOptions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
-
-        if (sdkLimitOptionsType == null)
-        {
-            Logger.LogTrace("SdkLimitOptions Type was not found");
-            return null;
-        }
-
-        MethodInfo? toOtlpSpanMethod = activityExtensionsType?.GetMethod(
-            "ToOtlpSpan",
-            BindingFlags.Static | BindingFlags.NonPublic,
-            null,
-            new[] { typeof(Activity), sdkLimitOptionsType },
-            null);
-
-        var request = new ExportTraceServiceRequest();
-        var sdkLimitOptions = this.GetSdkLimitOptions();
-
-        if (sdkLimitOptions == null)
-        {
-            Logger.LogTrace("SdkLimitOptions Object was not found/created properly using the default parameterless constructor");
-            return null;
-        }
-
-        OtlpResource.Resource? otlpResource = this.ToOtlpResource(this.processResource);
-
-        // Create a ResourceSpans instance to hold the span and the otlpResource
-        ResourceSpans resourceSpans = new ResourceSpans
-        {
-            Resource = otlpResource,
-        };
-        var scopeSpans = new ScopeSpans();
-
-        if (toOtlpSpanMethod != null)
-        {
-            foreach (var activity in batch)
-            {
-                var otlpSpan = toOtlpSpanMethod.Invoke(null, new object[] { activity, sdkLimitOptions });
-
-                // The converters below are required since the the JsonConvert.DeserializeObject doesn't
-                // know how to deserialize a BytesString or SpanKinds from otlp proto json object.
-                var settings = new JsonSerializerSettings();
-                settings.Converters.Add(new ByteStringConverter());
-                settings.Converters.Add(new SpanKindConverter());
-                settings.Converters.Add(new StatusCodeConverter());
-
-                // Below is a workaround to casting and works by converting an object into JSON then converting the
-                // JSON string back into the required object type. The reason casting isn't working is because of different
-                // assemblies being used. To use the protobuf library, we need to have a local copy of the protobuf assembly.
-                // Since upstream also has their own copy of the protobuf library, casting is not possible since the complier
-                // is recognizing them as two different types.
-                try
-                {
-                    var otlpSpanJson = otlpSpan?.ToString();
-                    if (otlpSpanJson == null)
-                    {
-                        continue;
-                    }
-
-                    var otlpSpanConverted = JsonConvert.DeserializeObject<Span>(otlpSpanJson, settings);
-                    scopeSpans.Spans.Add(otlpSpanConverted);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError($"Error converting OtlpSpan to/from JSON: {ex.Message}");
-                }
-            }
-
-            resourceSpans.ScopeSpans.Add(scopeSpans);
-            request.ResourceSpans.Add(resourceSpans);
-        }
-        else
-        {
-            Logger.LogTrace("ActivityExtensions.ToOtlpSpan method is not found");
-        }
-
-        return request.ToByteArray();
     }
 }
 
@@ -309,85 +137,5 @@ internal class UdpExporter
         {
             throw new ArgumentException($"Invalid endpoint: {endpoint}", ex);
         }
-    }
-}
-
-internal class ByteStringConverter : JsonConverter<ByteString>
-{
-    /// <inheritdoc/>
-    public override ByteString? ReadJson(JsonReader reader, Type objectType, ByteString? existingValue, bool hasExistingValue, JsonSerializer serializer)
-    {
-        var base64String = (string?)reader.Value;
-        return ByteString.FromBase64(base64String);
-    }
-
-    /// <inheritdoc/>
-    public override void WriteJson(JsonWriter writer, ByteString? value, JsonSerializer serializer)
-    {
-        writer.WriteValue(value?.ToBase64());
-    }
-}
-
-internal class SpanKindConverter : JsonConverter<Span.Types.SpanKind>
-{
-    /// <inheritdoc/>
-    public override Span.Types.SpanKind ReadJson(JsonReader reader, Type objectType, Span.Types.SpanKind existingValue, bool hasExistingValue, JsonSerializer serializer)
-    {
-        // Handle the string to enum conversion
-        string? enumString = reader.Value?.ToString();
-
-        // Convert the string representation to the corresponding enum value
-        switch (enumString)
-        {
-            case "SPAN_KIND_CLIENT":
-                return Span.Types.SpanKind.Client;
-            case "SPAN_KIND_SERVER":
-                return Span.Types.SpanKind.Server;
-            case "SPAN_KIND_INTERNAL":
-                return Span.Types.SpanKind.Internal;
-            case "SPAN_KIND_PRODUCER":
-                return Span.Types.SpanKind.Producer;
-            case "SPAN_KIND_CONSUMER":
-                return Span.Types.SpanKind.Consumer;
-            default:
-                throw new JsonSerializationException($"Unknown SpanKind: {enumString}");
-        }
-    }
-
-    /// <inheritdoc/>
-    public override void WriteJson(JsonWriter writer, Span.Types.SpanKind value, JsonSerializer serializer)
-    {
-        // Write the string representation of the enum
-        writer.WriteValue(value.ToString());
-    }
-}
-
-internal class StatusCodeConverter : JsonConverter<Status.Types.StatusCode>
-{
-    /// <inheritdoc/>
-    public override Status.Types.StatusCode ReadJson(JsonReader reader, Type objectType, Status.Types.StatusCode existingValue, bool hasExistingValue, JsonSerializer serializer)
-    {
-        // Handle the string to enum conversion
-        string? enumString = reader.Value?.ToString();
-
-        // Convert the string representation to the corresponding enum value
-        switch (enumString)
-        {
-            case "STATUS_CODE_UNSET":
-                return Status.Types.StatusCode.Unset;
-            case "STATUS_CODE_OK":
-                return Status.Types.StatusCode.Ok;
-            case "STATUS_CODE_ERROR":
-                return Status.Types.StatusCode.Error;
-            default:
-                throw new JsonSerializationException($"Unknown StatusCode: {enumString}");
-        }
-    }
-
-    /// <inheritdoc/>
-    public override void WriteJson(JsonWriter writer, Status.Types.StatusCode value, JsonSerializer serializer)
-    {
-        // Write the string representation of the enum
-        writer.WriteValue(value.ToString());
     }
 }


### PR DESCRIPTION
*Description of changes:*
Moved SerializeSpans method to a separate utils class as it will be needed to be implement SigV4 functionality.


Manually tested auto instrumentation on lambda to show that it was not broken with these changes:

<img width="1375" alt="image" src="https://github.com/user-attachments/assets/2d7dd0a4-e7c2-43f1-9921-7194ff3b92a2" />

```
{
    "Id": "1-67be63d6-37ebcd991a788d860351686b",
    "Duration": 0.355,
    "LimitExceeded": false,
    "Segments": [
        {
            "Id": "795cfe1337944950",
            "Document": {
                "id": "795cfe1337944950",
                "name": "SimpleLambdaFunction",
                "start_time": 1740530646.628895,
                "trace_id": "1-67be63d6-37ebcd991a788d860351686b",
                "end_time": 1740530646.973591,
                "parent_id": "1b42007b112b14ea",
                "aws": {
                    "lambda.name": "SimpleLambdaFunction",
                    "xray.origin": "AWS::Lambda::Function",
                    "cloudwatch_logs": [
                        {
                            "log_group": "/aws/lambda/SimpleLambdaFunction"
                        }
                    ]
                },
                "annotations": {
                    "aws:responseLatency": 343.391,
                    "aws:span.name": "SimpleLambdaFunction/LambdaExecutionEnvironment",
                    "aws:runtimeOverhead": 0.854,
                    "aws:span.kind": "SERVER",
                    "aws:responseDuration": 0.065
                },
                "metadata": {
                    "cloud.provider": "aws",
                    "service.name": "SimpleLambdaFunction",
                    "faas.name": "SimpleLambdaFunction",
                    "cloud.platform": "aws_lambda"
                },
                "origin": "AWS::Lambda::Function",
                "subsegments": [
                    {
                        "id": "0c4c85bfeb5f4c13",
                        "name": "Overhead",
                        "start_time": 1740530646.9699998,
                        "end_time": 1740530646.9708538,
                        "aws": {
                            "lambda.name": "Overhead",
                            "xray.origin": "AWS::Lambda::Function"
                        },
                        "annotations": {
                            "span.name": "Overhead/LambdaExecutionEnvironment",
                            "span.kind": "INTERNAL"
                        },
                        "metadata": {
                            "cloud.provider": "aws",
                            "service.name": "Overhead",
                            "faas.name": "Overhead",
                            "cloud.platform": "aws_lambda"
                        }
                    }
                ]
            }
        },
        {
            "Id": "1b42007b112b14ea",
            "Document": {
                "id": "1b42007b112b14ea",
                "name": "SimpleLambdaFunction",
                "start_time": 1740530646.621,
                "trace_id": "1-67be63d6-37ebcd991a788d860351686b",
                "end_time": 1740530646.976,
                "http": {
                    "response": {
                        "status": 200
                    }
                },
                "aws": {
                    "lambda.name": "SimpleLambdaFunction",
                    "span.kind": "LOCAL_ROOT",
                    "xray.origin": "AWS::Lambda",
                    "request_id": "10a113d4-28e1-431a-bb14-56a05973908a"
                },
                "annotations": {
                    "aws:span.name": "SimpleLambdaFunction/LambdaService",
                    "aws:aws.local.environment": "lambda:default",
                    "aws:aws.local.service": "SimpleLambdaFunction",
                    "aws:span.kind": "SERVER",
                    "aws:aws.local.operation": "SimpleLambdaFunction/LambdaService"
                },
                "metadata": {
                    "http.status_code": 200,
                    "cloud.provider": "aws",
                    "faas.invocation_id": "10a113d4-28e1-431a-bb14-56a05973908a",
                    "telemetry.extended": "true",
                    "service.name": "SimpleLambdaFunction",
                    "faas.name": "SimpleLambdaFunction",
                    "cloud.resource_id": "arn:aws:lambda:us-east-1:571600841604:function:SimpleLambdaFunction",
                    "PlatformType": "AWS::Lambda",
                    "http.response.status_code": 200,
                    "faas.trigger": "http",
                    "cloud.platform": "aws_lambda"
                },
                "origin": "AWS::Lambda"
            }
        },
        {
            "Id": "f7989d16b4f6feab",
            "Document": {
                "id": "f7989d16b4f6feab",
                "name": "SimpleLambdaFunction",
                "start_time": 1740530646.6710236,
                "trace_id": "1-67be63d6-37ebcd991a788d860351686b",
                "end_time": 1740530646.9644804,
                "parent_id": "795cfe1337944950",
                "http": {
                    "response": {
                        "status": 200
                    }
                },
                "aws": {
                    "span.kind": "LOCAL_ROOT",
                    "cloudwatch_logs": [
                        {
                            "log_group": "/aws/lambda/SimpleLambdaFunction"
                        }
                    ]
                },
                "annotations": {
                    "aws.local.service": "SimpleLambdaFunction",
                    "span.name": "SimpleLambdaFunction",
                    "aws.local.operation": "SimpleLambdaFunction/FunctionHandler",
                    "span.kind": "SERVER",
                    "aws.local.environment": "lambda:default"
                },
                "metadata": {
                    "telemetry.distro.version": "1.6.0.dev0-aws",
                    "process.runtime.version": "8.0.10",
                    "os.type": "linux",
                    "process.pid": 2,
                    "os.version": "2023",
                    "telemetry.sdk.name": "opentelemetry",
                    "process.owner": "sbx_user1051",
                    "telemetry.sdk.language": "dotnet",
                    "process.runtime.name": ".NET",
                    "os.description": "Amazon Linux 2023.6.20241010",
                    "os.name": "Amazon Linux",
                    "host.name": "169",
                    "telemetry.sdk.version": "1.9.0",
                    "service.name": "SimpleLambdaFunction",
                    "cloud.region": "us-east-1",
                    "faas.name": "SimpleLambdaFunction",
                    "telemetry.distro.name": "aws-otel-dotnet-instrumentation",
                    "faas.execution": "10a113d4-28e1-431a-bb14-56a05973908a",
                    "faas.id": "arn:aws:lambda:us-east-1:571600841604:function:SimpleLambdaFunction",
                    "http.status_code": 200,
                    "cloud.provider": "aws",
                    "cloud.account.id": "571600841604",
                    "faas.instance": "2025/02/26/[$LATEST]8f201b2e96aa444b99ca6740260f0ded",
                    "os.build_id": "5.10.233-244.887.amzn2.x86_64",
                    "faas.version": "$LATEST",
                    "PlatformType": "AWS::Lambda",
                    "process.runtime.description": ".NET 8.0.10",
                    "faas.trigger": "other"
                },
                "subsegments": [
                    {
                        "id": "70550b83e147ba87",
                        "name": "S3",
                        "start_time": 1740530646.9100933,
                        "end_time": 1740530646.9641554,
                        "http": {
                            "response": {
                                "status": 200,
                                "content_length": 0
                            }
                        },
                        "aws": {
                            "span.kind": "CLIENT",
                            "service": "S3",
                            "requestId": "4HC96HS6FBME53NA",
                            "region": "us-east-1",
                            "cloudwatch_logs": [
                                {
                                    "log_group": "/aws/lambda/SimpleLambdaFunction"
                                }
                            ],
                            "operation": "ListBuckets"
                        },
                        "annotations": {
                            "aws.local.service": "SimpleLambdaFunction",
                            "span.name": "S3.ListBuckets",
                            "aws.local.operation": "SimpleLambdaFunction/FunctionHandler",
                            "span.kind": "CLIENT",
                            "aws.remote.service": "AWS::S3",
                            "aws.remote.operation": "ListBuckets",
                            "aws.local.environment": "lambda:default"
                        },
                        "metadata": {
                            "telemetry.distro.version": "1.6.0.dev0-aws",
                            "rpc.service": "S3",
                            "process.runtime.version": "8.0.10",
                            "os.type": "linux",
                            "process.pid": 2,
                            "os.version": "2023",
                            "telemetry.sdk.name": "opentelemetry",
                            "process.owner": "sbx_user1051",
                            "telemetry.sdk.language": "dotnet",
                            "process.runtime.name": ".NET",
                            "os.description": "Amazon Linux 2023.6.20241010",
                            "rpc.method": "ListBuckets",
                            "os.name": "Amazon Linux",
                            "host.name": "169",
                            "telemetry.sdk.version": "1.9.0",
                            "service.name": "SimpleLambdaFunction",
                            "cloud.region": "us-east-1",
                            "faas.name": "SimpleLambdaFunction",
                            "telemetry.distro.name": "aws-otel-dotnet-instrumentation",
                            "rpc.system": "aws-api",
                            "http.status_code": 200,
                            "cloud.provider": "aws",
                            "http.response_content_length": 0,
                            "faas.instance": "2025/02/26/[$LATEST]8f201b2e96aa444b99ca6740260f0ded",
                            "os.build_id": "5.10.233-244.887.amzn2.x86_64",
                            "faas.version": "$LATEST",
                            "PlatformType": "AWS::Lambda",
                            "process.runtime.description": ".NET 8.0.10"
                        },
                        "namespace": "aws"
                    },
                    {
                        "id": "6694a827a5552e77",
                        "name": "aws.amazon.com:443",
                        "start_time": 1740530646.6713285,
                        "end_time": 1740530646.8781052,
                        "http": {
                            "request": {
                                "url": "https://aws.amazon.com/",
                                "method": "GET"
                            },
                            "response": {
                                "status": 200
                            }
                        },
                        "aws": {
                            "span.kind": "CLIENT",
                            "cloudwatch_logs": [
                                {
                                    "log_group": "/aws/lambda/SimpleLambdaFunction"
                                }
                            ]
                        },
                        "annotations": {
                            "aws.local.service": "SimpleLambdaFunction",
                            "span.name": "GET",
                            "aws.local.operation": "SimpleLambdaFunction/FunctionHandler",
                            "span.kind": "CLIENT",
                            "aws.remote.service": "aws.amazon.com:443",
                            "aws.remote.operation": "GET /",
                            "aws.local.environment": "lambda:default"
                        },
                        "metadata": {
                            "telemetry.distro.version": "1.6.0.dev0-aws",
                            "process.runtime.version": "8.0.10",
                            "os.type": "linux",
                            "process.pid": 2,
                            "os.version": "2023",
                            "telemetry.sdk.name": "opentelemetry",
                            "server.address": "aws.amazon.com",
                            "process.owner": "sbx_user1051",
                            "telemetry.sdk.language": "dotnet",
                            "process.runtime.name": ".NET",
                            "http.request.method": "GET",
                            "os.description": "Amazon Linux 2023.6.20241010",
                            "server.port": 443,
                            "os.name": "Amazon Linux",
                            "host.name": "169",
                            "telemetry.sdk.version": "1.9.0",
                            "url.full": "https://aws.amazon.com/",
                            "http.response.status_code": 200,
                            "service.name": "SimpleLambdaFunction",
                            "cloud.region": "us-east-1",
                            "network.protocol.version": "1.1",
                            "faas.name": "SimpleLambdaFunction",
                            "telemetry.distro.name": "aws-otel-dotnet-instrumentation",
                            "cloud.provider": "aws",
                            "faas.instance": "2025/02/26/[$LATEST]8f201b2e96aa444b99ca6740260f0ded",
                            "os.build_id": "5.10.233-244.887.amzn2.x86_64",
                            "faas.version": "$LATEST",
                            "PlatformType": "AWS::Lambda",
                            "process.runtime.description": ".NET 8.0.10"
                        },
                        "namespace": "remote"
                    }
                ]
            }
        },
        {
            "Id": "32ec6369351936d2",
            "Document": {
                "id": "32ec6369351936d2",
                "name": "aws.amazon.com:443",
                "start_time": 1740530646.6713285,
                "trace_id": "1-67be63d6-37ebcd991a788d860351686b",
                "end_time": 1740530646.8781052,
                "parent_id": "6694a827a5552e77",
                "inferred": true,
                "http": {
                    "request": {
                        "url": "https://aws.amazon.com/",
                        "method": "GET"
                    },
                    "response": {
                        "status": 200
                    }
                },
                "annotations": {
                    "aws.local.service": "aws.amazon.com:443",
                    "aws.local.operation": "GET /"
                }
            }
        },
        {
            "Id": "39afe650138f1515",
            "Document": {
                "id": "39afe650138f1515",
                "name": "S3",
                "start_time": 1740530646.9100933,
                "trace_id": "1-67be63d6-37ebcd991a788d860351686b",
                "end_time": 1740530646.9641554,
                "parent_id": "70550b83e147ba87",
                "inferred": true,
                "http": {
                    "response": {
                        "status": 200,
                        "content_length": 0
                    }
                },
                "aws": {
                    "span.kind": "CLIENT",
                    "service": "S3",
                    "requestId": "4HC96HS6FBME53NA",
                    "region": "us-east-1",
                    "cloudwatch_logs": [
                        {
                            "log_group": "/aws/lambda/SimpleLambdaFunction"
                        }
                    ],
                    "operation": "ListBuckets"
                },
                "annotations": {
                    "aws.local.service": "AWS::S3",
                    "aws.local.operation": "ListBuckets"
                },
                "origin": "AWS::S3"
            }
        }
    ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

