### PR TITLE
feat: Updating Release Build Workflow to Sign UDP Exporter Files

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -352,6 +352,7 @@ jobs:
         run: |
           .\buildtools\sign_files.ps1 -Filters AWS.Distro.OpenTelemetry.AutoInstrumentation.dll -Recurse -Path .\src\AWS.Distro.OpenTelemetry.AutoInstrumentation\bin\Release
           .\buildtools\sign_files.ps1 -Filters OpenTelemetry.Instrumentation.AWS.dll -Recurse -Path .\src\AWS.Distro.OpenTelemetry.AutoInstrumentation\bin\Release
+          .\buildtools\sign_files.ps1 -Filters AWS.OpenTelemetry.Exporter.Otlp.Udp.dll -Recurse -Path .\exporters\AWS.OpenTelemetry.Exporter.Otlp.Udp\bin\Release
           
       - name: Pack nugets
         run: >

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -352,7 +352,7 @@ jobs:
         run: |
           .\buildtools\sign_files.ps1 -Filters AWS.Distro.OpenTelemetry.AutoInstrumentation.dll -Recurse -Path .\src\AWS.Distro.OpenTelemetry.AutoInstrumentation\bin\Release
           .\buildtools\sign_files.ps1 -Filters OpenTelemetry.Instrumentation.AWS.dll -Recurse -Path .\src\AWS.Distro.OpenTelemetry.AutoInstrumentation\bin\Release
-          .\buildtools\sign_files.ps1 -Filters AWS.OpenTelemetry.Exporter.Otlp.Udp.dll -Recurse -Path .\exporters\AWS.OpenTelemetry.Exporter.Otlp.Udp\bin\Release
+          .\buildtools\sign_files.ps1 -Filters AWS.OpenTelemetry.Exporter.Otlp.Udp.dll -Recurse -Path .\src\AWS.Distro.OpenTelemetry.AutoInstrumentation\bin\Release
           
       - name: Pack nugets
         run: >


### PR DESCRIPTION
**Description of changes:**
One-liner to sign the new dll files in the ADOT package. 
- Related changes: https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/183

**Test Plan:**
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

