### PR TITLE
[Bug] Fixed SigV4 Signer not Automatically Injecting Security Token Header

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/OtlpAwsSpanExporter/OtlpAwsSpanExporter.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/OtlpAwsSpanExporter/OtlpAwsSpanExporter.cs
@@ -218,7 +218,7 @@ internal class RetryHelper
     // This is to ensure there is no flakiness with the number of times spans are exported in the retry window. Not part of the upstream's implementation
     private const int BufferWindow = 20;
     private static readonly ILoggerFactory Factory = LoggerFactory.Create(builder => builder.AddProvider(new ConsoleLoggerProvider()));
-    private static readonly ILogger Logger = Factory.CreateLogger<RetryHelper>();
+    private static readonly ILogger Logger = Factory.CreateLogger<OtlpAwsSpanExporter>();
 
 #if !NET6_0_OR_GREATER
     private static readonly Random Randomizer = new Random();
@@ -243,7 +243,7 @@ internal class RetryHelper
             {
                 if (HasDeadlinePassed(deadline, 0))
                 {
-                    Logger.LogInformation("Timeout of {Deadline}ms reached, stopping retries", deadline.Millisecond);
+                    Logger.LogDebug("Timeout of {Deadline}ms reached, stopping retries", deadline.Millisecond);
                     return response;
                 }
 
@@ -283,12 +283,12 @@ internal class RetryHelper
                     delayDuration = TimeSpan.FromMilliseconds(GetRandomNumber(0, currentDelay));
                 }
 
-                Logger.LogInformation("Spans were not exported with status code: {StatusCode}. Checking to see if retryable again after: {DelayMilliseconds} ms", response.StatusCode, delayDuration.Milliseconds);
+                Logger.LogDebug("Spans were not exported with status code: {StatusCode}. Checking to see if retryable again after: {DelayMilliseconds} ms", response.StatusCode, delayDuration.Milliseconds);
 
                 // If delay exceeds deadline. We drop the http requesst completely.
                 if (HasDeadlinePassed(deadline, delayDuration.Milliseconds))
                 {
-                    Logger.LogInformation("Timeout will be reached after {Delay}ms delay. Dropping Spans with status code {StatusCode}.", delayDuration.Milliseconds, response.StatusCode);
+                    Logger.LogDebug("Timeout will be reached after {Delay}ms delay. Dropping Spans with status code {StatusCode}.", delayDuration.Milliseconds, response.StatusCode);
                     return response;
                 }
 
@@ -306,14 +306,14 @@ internal class RetryHelper
                     currentDelay = CalculateNextRetryDelay(currentDelay);
                     if (!HasDeadlinePassed(deadline, delayDuration.Milliseconds))
                     {
-                        Logger.LogInformation("{@ExceptionMessage}. Retrying again after {@Delay}ms", exceptionName, delayDuration.Milliseconds);
+                        Logger.LogDebug("{@ExceptionMessage}. Retrying again after {@Delay}ms", exceptionName, delayDuration.Milliseconds);
 
                         await Task.Delay(delayDuration);
                         continue;
                     }
                 }
 
-                Logger.LogInformation("Timeout will be reached after {Delay}ms delay. Dropping spans with exception: {@ExceptionMessage}", delayDuration.Milliseconds, e);
+                Logger.LogDebug("Timeout will be reached after {Delay}ms delay. Dropping spans with exception: {@ExceptionMessage}", delayDuration.Milliseconds, e);
                 throw;
             }
         }


### PR DESCRIPTION
*Issue #, if available:*
The internal AWS SDK SigV4 signer does not automatically inject the x-amz-security-token header into the request when signing.

This leads to a 403 Forbidden error when users use the SigV4 exporter and use temporary credentials from Amazon STS.

*Description of changes:*
Manually injected the security token header into the outgoing request before making the export.

*Testing*
Manual testing was done by running the DotNet Auto Instrumentation on a sample application hosted on a newly created EC2 instance with sufficient permissions to export to XRay OTLP endpoint without editing the local aws config file and verified that the spans exported were showing up on CW Logs aws/spans.

<img width="1584" alt="image" src="https://github.com/user-attachments/assets/bb9fe2fd-26be-4af7-a7a0-2bf2398fdf5b" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

