### PR TITLE
Add SigV4 release test to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -157,7 +157,15 @@ jobs:
       aws-region: us-east-1
       caller-workflow-name: 'main-build'
       staging_distro_name: ${{ inputs.ec2-windows-image-name }}
-      
+
+  dotnet-ec2-adot-sigv4-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-ec2-adot-sigv4-test.yml@main
+    secrets: inherit
+    with:
+      caller-workflow-name: 'main-build'
+      staging_distro_name: ${{ inputs.ec2-windows-image-name }}
+
   dotnet-eks-linux-test:
     needs: [ upload-main-build, upload-main-build-image ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-eks-test.yml@main


### PR DESCRIPTION
Follow up to: [aws-observability/aws-application-signals-test-framework #380](https://github.com/aws-observability/aws-application-signals-test-framework/pull/380)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

