### PR TITLE
feat: add lambda env detection logic for udp exporter setup

### DIFF
--- a/exporters/AWS.Distro.OpenTelemetry.Exporter.Xray.Udp/OtlpUdpExporter.cs
+++ b/exporters/AWS.Distro.OpenTelemetry.Exporter.Xray.Udp/OtlpUdpExporter.cs
@@ -32,7 +32,15 @@ public class OtlpUdpExporter : BaseExporter<Activity>
     /// <param name="processResource">Otel Resource object</param>
     public OtlpUdpExporter(Resource processResource, string? endpoint = null, string? signalPrefix = null)
     {
-        endpoint = endpoint ?? UdpExporter.DefaultEndpoint;
+        // Check if running in AWS Lambda environment
+        if (endpoint == null && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")))
+        {
+            endpoint = Environment.GetEnvironmentVariable("AWS_XRAY_DAEMON_ADDRESS") ?? UdpExporter.DefaultEndpoint;
+        }
+        else
+        {
+            endpoint = endpoint ?? UdpExporter.DefaultEndpoint;
+        }
         this.udpExporter = new UdpExporter(endpoint);
         this.signalPrefix = signalPrefix ?? UdpExporter.DefaultFormatOtelTracesBinaryPrefix;
         this.processResource = processResource;


### PR DESCRIPTION
## What does this pull request do?
Adds logic to handle UDP exporter set up for Lambda environments [similar to Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/exporters/aws-otel-otlp-udp-exporter/src/amazon/opentelemetry/exporters/otlp/udp/exporter.py#L60-L62).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

