### PR TITLE
Updated GH release to create a draft

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -106,6 +106,7 @@ jobs:
         run: |
           gh release create --target "$GITHUB_REF_NAME" \
              --title "Release v${{ github.event.inputs.version }}" \
+             --draft \
              "v${{ github.event.inputs.version }}" \
               --notes "Release Verions v${{ github.event.inputs.version }}"
 


### PR DESCRIPTION
*Description of changes:*
Updated GH release to create a draft instead of publishing it. This was causing issues since part of the workflow is trying to retrieve zip files from the previous latest release. However, without the --draft option, the workflow publishes the new release which is then set as latest causing the workflow to fail when trying to get files from a brand new empty release. 

Caught this issue on the most recent release and pushing a fix in a custom branch fixed the issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

