### PR TITLE
[FIX] Move inputs in pre-release to env vars

### DIFF
--- a/.github/workflows/pre_release_prepare.yml
+++ b/.github/workflows/pre_release_prepare.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  VERSION: ${{ inputs.version }}
+  IS_PATCH: ${{ inputs.is_patch }}
 
 permissions:
   contents: write
@@ -52,12 +54,12 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo ${{ env.VERSION }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Create branches
         run: |
-          IS_PATCH=${{ github.event.inputs.is_patch }}
+          IS_PATCH=${{ env.IS_PATCH }}
           if [[ "$IS_PATCH" != "true" && "$IS_PATCH" != "false" ]]; then
             echo "Invalid input for IS_PATCH. Must be 'true' or 'false'."
             exit 1
@@ -103,5 +105,5 @@ jobs:
                        --body "This PR updates the version to ${VERSION}.
           
           By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice." \
-                       --head v${{ github.event.inputs.version }}_release \
+                       --head v${{ env.VERSION }}_release \
                        --base release/v${MAJOR_MINOR}.x


### PR DESCRIPTION
GitHub cleans data when processed this way in case of abuse attempts when running workflows. Following other repo as an example: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/dotnet-lambda-test.yml#L28


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

