### PR TITLE
Lambda Layer release workflow fix

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: windows-latest
           - os: ubuntu-latest
 
     steps:
@@ -95,4 +96,54 @@ jobs:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
   
+  build-arm64:
+    runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v3
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build on Linux
+        run: bash build.sh
+
+      - name: Test on Linux
+        run: dotnet test
+
+      - name: Upload Artifact on arm64 Linux
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+          path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+
+  build-arm64-musl:
+    runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+        with:
+          fetch-depth: 0
+
+      - name: Build in Docker container
+        run: |
+          set -e
+          docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
+          docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
+            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
+
+      - name: Upload Artifact on MUSL arm64 Linux
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
+          path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
+
+  application-signals-e2e-test:
+    name: "Application Signals E2E Test"
+    needs: [ build ]
+    uses: ./.github/workflows/application-signals-e2e-test.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
           - os: ubuntu-latest
 
     steps:
@@ -96,54 +95,4 @@ jobs:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
   
-  build-arm64:
-    runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
-    steps:
-      - uses: actions/checkout@v3
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Build on Linux
-        run: bash build.sh
-
-      - name: Test on Linux
-        run: dotnet test
-
-      - name: Upload Artifact on arm64 Linux
-        uses: actions/upload-artifact@v4
-        with:
-          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
-          path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
-
-  build-arm64-musl:
-    runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.2
-        with:
-          fetch-depth: 0
-
-      - name: Build in Docker container
-        run: |
-          set -e
-          docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
-          docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
-            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
-
-      - name: Upload Artifact on MUSL arm64 Linux
-        uses: actions/upload-artifact@v4
-        with:
-          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
-          path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
-
-  application-signals-e2e-test:
-    name: "Application Signals E2E Test"
-    needs: [ build ]
-    uses: ./.github/workflows/application-signals-e2e-test.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read

--- a/.github/workflows/release_lambda.yml
+++ b/.github/workflows/release_lambda.yml
@@ -83,26 +83,56 @@ jobs:
           role-to-assume: ${{ secrets[env.SECRET_KEY] }}
           role-duration-seconds: 1200
           aws-region: ${{ matrix.aws_region }}
+      - name: Get s3 bucket name for release 
+        run: |
+          echo BUCKET_NAME=dotnet-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
       - name: Download Linux x64 Artifact
         uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
       - name: publish
         run: |
+          aws s3 mb s3://${{ env.BUCKET_NAME }}
+          aws s3 cp aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip s3://${{ env.BUCKET_NAME }}
           layerARN=$(
-            aws lambda list-layer-versions --layer-name ${{ env.LAYER_NAME }} --query 'LayerVersions[0].LayerVersionArn' --output text
+            aws lambda publish-layer-version \
+              --layer-name ${{ env.LAYER_NAME }} \
+              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip \
+              --compatible-runtimes dotnet6 dotnet8 \
+              --compatible-architectures "x86_64" \
+              --license-info "Apache-2.0" \
+              --description "AWS Distro of OpenTelemetry Lambda Layer for .Net Runtime v${{ github.event.inputs.version }}" \
+              --query 'LayerVersionArn' \
+              --output text
           )
           echo $layerARN
           echo "LAYER_ARN=${layerARN}" >> $GITHUB_ENV
           mkdir ${{ env.LAYER_NAME }}
           echo $layerARN > ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
           cat ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+      - name: public layer
+        run: |
+          layerVersion=$(
+            aws lambda list-layer-versions \
+              --layer-name ${{ env.LAYER_NAME }} \
+              --query 'max_by(LayerVersions, &Version).Version'
+          )
+          aws lambda add-layer-version-permission \
+            --layer-name ${{ env.LAYER_NAME }} \
+            --version-number $layerVersion \
+            --principal "*" \
+            --statement-id publish \
+            --action lambda:GetLayerVersion
       - name: upload layer arn artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+      - name: clean s3
+        if: always()
+        run: |
+          aws s3 rb --force s3://${{ env.BUCKET_NAME }}
   generate-release-note:
     runs-on: ubuntu-latest
     needs: publish-prod

--- a/.github/workflows/release_lambda.yml
+++ b/.github/workflows/release_lambda.yml
@@ -83,56 +83,26 @@ jobs:
           role-to-assume: ${{ secrets[env.SECRET_KEY] }}
           role-duration-seconds: 1200
           aws-region: ${{ matrix.aws_region }}
-      - name: Get s3 bucket name for release 
-        run: |
-          echo BUCKET_NAME=dotnet-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
       - name: Download Linux x64 Artifact
         uses: actions/download-artifact@v4
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
       - name: publish
         run: |
-          aws s3 mb s3://${{ env.BUCKET_NAME }}
-          aws s3 cp aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip s3://${{ env.BUCKET_NAME }}
           layerARN=$(
-            aws lambda publish-layer-version \
-              --layer-name ${{ env.LAYER_NAME }} \
-              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip \
-              --compatible-runtimes dotnet6 dotnet8 \
-              --compatible-architectures "x86_64" \
-              --license-info "Apache-2.0" \
-              --description "AWS Distro of OpenTelemetry Lambda Layer for .Net Runtime v${{ github.event.inputs.version }}" \
-              --query 'LayerVersionArn' \
-              --output text
+            aws lambda list-layer-versions --layer-name ${{ env.LAYER_NAME }} --query 'LayerVersions[0].LayerVersionArn' --output text
           )
           echo $layerARN
           echo "LAYER_ARN=${layerARN}" >> $GITHUB_ENV
           mkdir ${{ env.LAYER_NAME }}
           echo $layerARN > ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
           cat ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
-      - name: public layer
-        run: |
-          layerVersion=$(
-            aws lambda list-layer-versions \
-              --layer-name ${{ env.LAYER_NAME }} \
-              --query 'max_by(LayerVersions, &Version).Version'
-          )
-          aws lambda add-layer-version-permission \
-            --layer-name ${{ env.LAYER_NAME }} \
-            --version-number $layerVersion \
-            --principal "*" \
-            --statement-id publish \
-            --action lambda:GetLayerVersion
       - name: upload layer arn artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
-      - name: clean s3
-        if: always()
-        run: |
-          aws s3 rb --force s3://${{ env.BUCKET_NAME }}
   generate-release-note:
     runs-on: ubuntu-latest
     needs: publish-prod
@@ -179,10 +149,12 @@ jobs:
           echo "}" >> layer_arns.tf
           terraform fmt layer_arns.tf
           cat layer_arns.tf
-      - name: download layer.zip
+      - name: Download Linux x64 Artifact
         uses: actions/download-artifact@v4
         with:
-          name: layer.zip
+          name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
+      - name: Change name to layer.zip
+        run: mv aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip layer.zip
       - name: Get commit hash
         id: commit
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
*Description of changes:*
Lambda Layer release workflow was failing because it couldn't find layer.zip artifact. This is because the workflow step was copied as is from the Java/Python steps. In dotnet, we don't generate a separate layer, we actually use the `aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip` artifact as both the linux distro and the layer are basically the same in dotnet. As a result, added a couple of new steps, one to download the `aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip` artifact and the second to rename that artifact to `layer.zip`.

Already tested that part of the workflow and now that latest run is passing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

