### PR TITLE
fix udp publish to nuget release step

### DIFF
--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -85,6 +85,7 @@ jobs:
           --region ${{ env.AWS_SIGNING_KEY_REGION }}
           --output text
           --query SecretString | ConvertFrom-Json
+
           nuget push
           .\Deployment\nuget-packages\*.nupkg
           -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## What does this pull request do?
```
Run $nugetKey = aws secretsmanager get-secret-value --secret-id *** --region us-west-2 --output text --query SecretString | ConvertFrom-Json nuget push .\Deployment\nuget-packages\*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $nugetKey.Key
11ConvertFrom-Json: D:\a\_temp\a7d0dc99-0c8b-4fd5-9a40-c3595b71bd03.ps1:2
12Line |
13 2 | … retString | ConvertFrom-Json nuget push .\Deployment\nuget-packages\* …
14 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
15 | A positional parameter cannot be found that accepts argument 'push'.
16Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='cp1252'>
17OSError: [Errno 22] Invalid argument
18Error: Process completed with exit code 1.
```
Fixes a syntax error in workflow file was causing the above error.

The error message indicates that PowerShell is trying to interpret "nuget push" as arguments to the ConvertFrom-Json cmdlet, rather than as a separate command so adding newline [as found in our ADOT release workflow](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/.github/workflows/release_build.yml#L386).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

