### PR TITLE
fix api key issue in udp exporter nuget publishing

### DIFF
--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -80,16 +80,9 @@ jobs:
 
       - name: Push packages to Nuget
         run: >
-          $nugetKey = aws secretsmanager get-secret-value
-          --secret-id ${{ secrets.NUGET_SECRETS_ID }}
-          --region ${{ env.AWS_SIGNING_KEY_REGION }}
-          --output text
-          --query SecretString | ConvertFrom-Json
+          $nugetKey = aws secretsmanager get-secret-value --secret-id ${{ secrets.NUGET_SECRETS_ID }} --region ${{ env.AWS_SIGNING_KEY_REGION }} --output text --query SecretString | ConvertFrom-Json
 
-          nuget push
-          .\Deployment\nuget-packages\*.nupkg
-          -Source https://api.nuget.org/v3/index.json
-          -ApiKey $nugetKey.Key
+          dotnet nuget push .\Deployment\nuget-packages\*.nupkg --api-key $nugetKey.Key --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create Release Notes
         run: |


### PR DESCRIPTION
## What does this PR do?
```
Run $nugetKey = aws secretsmanager get-secret-value --secret-id *** --region us-west-2 --output text --query SecretString | ConvertFrom-Json
Pushing AWS.Distro.OpenTelemetry.Exporter.Xray.Udp.0.0.1.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Forbidden https://www.nuget.org/api/v2/package/ 739ms
Response status code does not indicate success: 403 (The specified API key is invalid, has expired, or does not have permission to access the specified package.).
```

Switching the CLI tool used to publish the UDP exporter to `dotnet nuget` to try and resolve the above API key error. This should ensure that the command uses the [specified v3 endpoint](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/.github/workflows/release-udp-exporter.yml#L91) to confirm if the v2 endpoint is causing the credentials error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

