### PR TITLE
fix: udp exporter release api key error

### DIFF
--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -26,6 +26,7 @@ jobs:
   build-release-udp-exporter-nuget:
     # Only release if previous e2e test succeeds
     needs: validate-udp-exporter-e2e-test
+    environment: Release
     runs-on: windows-latest
 
     strategy:
@@ -45,7 +46,7 @@ jobs:
           --no-restore
 
       - name: Assume signer role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ARTIFACT_ACCESS_ROLE_ARN }}
           aws-region: ${{ env.AWS_SIGNING_KEY_REGION }}
@@ -73,7 +74,7 @@ jobs:
           path: Deployment/nuget-packages/
 
       - name: Assume nuget role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.NUGET_ACCESS_ROLE_ARN }}
           aws-region: ${{ env.AWS_SIGNING_KEY_REGION }}


### PR DESCRIPTION
## What does this pull request do?
An attempt to fix the API key error encountered when trying to publish the UDP Exporter to NuGet.

Since this workflow uses the same credentials as our .NET ADOT SDK release workflow, it was strange why [these errors](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/14579431706/job/40892706595) were occurring. After comparing the two workflow files ([ADOT SDK release workflow](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/.github/workflows/release_build.yml), [UDP Exporter release workflow](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/.github/workflows/release-udp-exporter.yml)), I noticed some discrepancies that I corrected with this PR's code changes.
```
Run $nugetKey = aws secretsmanager get-secret-value --secret-id *** --region us-west-2 --output text --query SecretString | ConvertFrom-Json
Pushing AWS.Distro.OpenTelemetry.Exporter.Xray.Udp.0.0.1.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Forbidden https://www.nuget.org/api/v2/package/ 739ms
Response status code does not indicate success: 403 (The specified API key is invalid, has expired, or does not have permission to access the specified package.).
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

