### PR TITLE
Updated otel pkg versions for the UDP Sample App

### DIFF
--- a/sample-applications/udp-exporter-test-app/dotnet-sample-app.csproj
+++ b/sample-applications/udp-exporter-test-app/dotnet-sample-app.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.406.2" />
     <PackageReference Include="OpenTelemetry.Contrib.Extensions.AWSXRay" Version="1.2.0" />
     <PackageReference Include="OpenTelemetry.Contrib.Instrumentation.AWS" Version="1.0.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.2.0" />
 


### PR DESCRIPTION
*Description of changes:*
After merging the latest UDP Exporter changes, the E2E test starting failing https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/14913437640/job/41893186439. Did some debugging locally and turns out the application isn't starting due to dependency conflicts. The OTEL dependencies were upgraded from v1.9 to v1.11 in the UDP exporter. This change updates them in the sample app as well. After making the changes locally, the sample app started as expected and I was able to grab a sample trace from there.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

