### PR TITLE
Updated service.name resource attribute logic in Plugin

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -541,7 +541,7 @@ public class Plugin
         {
             // service.name was not configured yet use the fallback.
             Logger.Log(LogLevel.Warning, "No valid service name provided. Using fallback logic of using assembly name!");
-            builder.AddAttributes([new (ResourceSemanticConventions.AttributeServiceName, this.GetFallbackServiceName())]);
+            builder.AddAttributes(new Dictionary<string, object> { { ResourceSemanticConventions.AttributeServiceName, this.GetFallbackServiceName() } });
         }
 
         // Incase the above logic failed to get assembly or process name for any reason

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -18,6 +18,7 @@ using OpenTelemetry.Instrumentation.AWSLambda;
 using System.Web;
 using OpenTelemetry.Instrumentation.AspNet;
 #endif
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using AWS.Distro.OpenTelemetry.AutoInstrumentation.Logging;
 using AWS.Distro.OpenTelemetry.Exporter.Xray.Udp;
@@ -193,7 +194,12 @@ public class Plugin
     {
         if (this.IsApplicationSignalsEnabled())
         {
-            var resourceBuilder = this.ResourceBuilderCustomizer(ResourceBuilder.CreateDefault());
+            var resourceBuilder = ResourceBuilder
+                .CreateEmpty() // Don't use CreateDefault because it puts service name unknown by default.
+                .AddEnvironmentVariableDetector()
+                .AddTelemetrySdk();
+
+            resourceBuilder = this.ResourceBuilderCustomizer(resourceBuilder);
             var resource = resourceBuilder.Build();
             var processor = AwsMetricAttributesSpanProcessorBuilder.Create(resource).Build();
             builder.AddProcessor(processor);
@@ -213,7 +219,12 @@ public class Plugin
     /// <returns>Returns configured builder</returns>
     public TracerProviderBuilder AfterConfigureTracerProvider(TracerProviderBuilder builder)
     {
-        var resourceBuilder = this.ResourceBuilderCustomizer(ResourceBuilder.CreateDefault());
+        var resourceBuilder = ResourceBuilder
+                .CreateEmpty() // Don't use CreateDefault because it puts service name unknown by default.
+                .AddEnvironmentVariableDetector()
+                .AddTelemetrySdk();
+
+        resourceBuilder = this.ResourceBuilderCustomizer(resourceBuilder);
         var resource = resourceBuilder.Build();
         this.sampler = SamplerUtil.GetSampler(resource);
 
@@ -526,10 +537,18 @@ public class Plugin
 
         builder.AddAttributes(DistroAttributes);
         var resource = builder.Build();
+        if (!resource.Attributes.Any(kvp => kvp.Key == ResourceSemanticConventions.AttributeServiceName))
+        {
+            // service.name was not configured yet use the fallback.
+            Logger.Log(LogLevel.Warning, "No valid service name provided. Using fallback logic of using assembly name!");
+            builder.AddAttributes([new (ResourceSemanticConventions.AttributeServiceName, this.GetFallbackServiceName())]);
+        }
+
+        // Incase the above logic failed to get assembly or process name for any reason
         var serviceName = (string?)resource.Attributes.FirstOrDefault(attr => attr.Key == ResourceSemanticConventions.AttributeServiceName).Value;
         if (serviceName == null || serviceName.StartsWith(OtelUnknownServicePrefix))
         {
-            Logger.Log(LogLevel.Warning, "No valid service name provided.");
+            Logger.Log(LogLevel.Warning, $"Fallback logic failed. Using {AwsSpanProcessingUtil.UnknownService} as service name!");
             serviceName = AwsSpanProcessingUtil.UnknownService;
         }
 
@@ -633,5 +652,44 @@ public class Plugin
         }
 
         return DefaultOtlpTracesTimeoutMilli;
+    }
+
+    private string GetFallbackServiceName()
+    {
+        try
+        {
+#if NETFRAMEWORK
+            // System.Web.dll is only available on .NET Framework
+            if (System.Web.Hosting.HostingEnvironment.IsHosted)
+            {
+                // if this app is an ASP.NET application, return "SiteName/ApplicationVirtualPath".
+                // note that ApplicationVirtualPath includes a leading slash.
+                return (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
+            }
+#endif
+            return Assembly.GetEntryAssembly()?.GetName().Name ?? this.GetCurrentProcessName();
+        }
+        catch
+        {
+            return "unknown_service";
+        }
+    }
+
+    /// <summary>
+    /// <para>Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.ProcessName"/></para>
+    /// <para>
+    /// On .NET Framework the <see cref="Process"/> class is guarded by a
+    /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
+    /// This exception is thrown when the caller method is being JIT compiled, NOT
+    /// when Process.GetCurrentProcess is called, so this wrapper method allows
+    /// us to catch the exception.
+    /// </para>
+    /// </summary>
+    /// <returns>Returns the name of the current process.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private string GetCurrentProcessName()
+    {
+        using var currentProcess = Process.GetCurrentProcess();
+        return currentProcess.ProcessName;
     }
 }

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -671,7 +671,7 @@ public class Plugin
         }
         catch
         {
-            return "unknown_service";
+            return OtelUnknownServicePrefix;
         }
     }
 

--- a/test/contract-tests/tests/test/amazon/misc/unknown_service_name_test.py
+++ b/test/contract-tests/tests/test/amazon/misc/unknown_service_name_test.py
@@ -15,6 +15,5 @@ class UnknownServiceNameTest(ResourceAttributesTest):
             pairlist.append(key + "=" + value)
         return ",".join(pairlist)
 
-    # TODO: metric service.name is set correctly, but span service.name is being set to AppSignals.NetCore.
     def test_service(self) -> None:
         self.do_test_resource_attributes("AppSignals.NetCore")

--- a/test/contract-tests/tests/test/amazon/misc/unknown_service_name_test.py
+++ b/test/contract-tests/tests/test/amazon/misc/unknown_service_name_test.py
@@ -16,5 +16,5 @@ class UnknownServiceNameTest(ResourceAttributesTest):
         return ",".join(pairlist)
 
     # TODO: metric service.name is set correctly, but span service.name is being set to AppSignals.NetCore.
-    # def test_service(self) -> None:
-    #     self.do_test_resource_attributes("unknown_service:dotnet")
+    def test_service(self) -> None:
+        self.do_test_resource_attributes("AppSignals.NetCore")


### PR DESCRIPTION
*Description of changes:*
Previously, there was an issue where the service.name attribute is the resource attributes for Traces and Metrics would be different when the service name is not set in the `OTEL_RESOURCE_ATTRIBUTES` env var. Turns out upstream has fallback logic that sets the service.name attribute to the assembly name if it's not set instead of using `unknown_service`. 
However, since we create our own MeterProvider for application signals, the fallback logic doesn't apply for those resources created outside of the opentelemetry instrumentation pkg. This PR adds this logic locally so that if service.name is empty, it calls the fallback function to get the assembly name or the process name. If either of that fail, then we default to `UnknownService`.

*Testing:*
Enabled [unknown_service_name_test.py](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/compare/resourceFix?expand=1#diff-7c7fd9bc584044176d3dace0f83bdc2d080e8c100c9d0561475122064ce951f6) and updated it to check for the assembly name because of the fallback logic instead of unknown_service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

