### PR TITLE
Move environment parameter to main-build

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -5,6 +5,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      environment:
+        required: false
+        type: string
+        default: Dev
+  
   push:
     branches:
       - main
@@ -17,6 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    environment: ${{ inputs.environment }}
     strategy:
       matrix:
         include:
@@ -77,6 +83,7 @@ jobs:
   
   build-x64-musl:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2
@@ -98,6 +105,7 @@ jobs:
   
   build-arm64:
     runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v3
 
@@ -120,6 +128,7 @@ jobs:
 
   build-arm64-musl:
     runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -21,7 +21,6 @@ permissions:
 
 jobs:
   build-and-upload:
-    environment: Release
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +29,7 @@ jobs:
     secrets: inherit
     with:
       caller-workflow-name: 'release_lambda_workflow'
+      environment: 'Release'
 
   setup-regions-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*
The lambda layer release workflow is failing because the environment parameter cannot be used while triggering a reusable workflow. 

*Description of changes:*
Moved the environment parameter to main-build and added input variable to specify the environment type

*Testing*:
Release Environment: https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/15937448883
Dev Environment: https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/15937444155


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

