### PR TITLE
Send main build metrics

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -171,8 +171,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          success="${{ needs.build.result == 'success' && needs.application-signals-e2e-test.result == 'success' }}"
-          value="${success}" == "true" && "0.0" || "1.0"
+          value="${{ needs.build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Emit a failure metric if main build fails. Since this workflow is triggered with pushes to main or a release branch, we want to be notified if there is a failure with the build process or e2e tests.

Tested by temporarily adding an `on: push:` trigger to my own branch in this repo and testing the updated workflow. Verified that failure metric was successfully published to cloudwatch.
https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/16764243839

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

