### PR TITLE
Add Missing EC2 ASG Test in Application Signals E2E Test Runs

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -156,6 +156,15 @@ jobs:
       caller-workflow-name: 'main-build'
       staging_distro_name: ${{ inputs.ec2-default-image-name }}
 
+  dotnet-ec2-asg-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-ec2-asg-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+      staging_distro_name: ${{ inputs.ec2-default-image-name }}
+
   dotnet-eks-linux-test:
     needs: [ upload-main-build, upload-main-build-image ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-eks-test.yml@main
@@ -242,4 +251,4 @@ jobs:
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
     with:
-      exclusions: dotnet-ec2-nuget-test.yml,dotnet-ec2-asg-test.yml
+      exclusions: dotnet-ec2-nuget-test.yml


### PR DESCRIPTION
### What does this pull request do?
Adds missing EC2 ASG Test. Did not add the missing NuGet test based on previous thread saying those tests are no longer relevant. Follow-up PRs will be made to remove the old NuGet tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

