### PR TITLE
chore: add asg test to the main build workflow

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -155,6 +155,15 @@ jobs:
     with:
       caller-workflow-name: 'main-build'
       staging_distro_name: ${{ inputs.ec2-default-image-name }}
+  
+  dotnet-asg-linux-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-ec2-asg-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+      staging_distro_name: ${{ inputs.ec2-default-image-name }}
 
   dotnet-eks-linux-test:
     needs: [ upload-main-build, upload-main-build-image ]
@@ -242,4 +251,4 @@ jobs:
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
     with:
-      exclusions: dotnet-ec2-nuget-test.yml,dotnet-ec2-asg-test.yml
+      exclusions: dotnet-ec2-nuget-test.yml


### PR DESCRIPTION
*Description of changes:*
Add EC2 auto-scaling group test case to the main build workflow.

Verified in the dry-run: https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/17566192132

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

