### PR TITLE
Add clarity for region variables in Lambda Layer release workflow

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -12,7 +12,8 @@ on:
         default: 'us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1, af-south-1, ap-east-1, ap-south-2, ap-southeast-3, ap-southeast-4, eu-central-2, eu-south-1, eu-south-2, il-central-1, me-central-1, me-south-1, ap-southeast-5, ap-southeast-7, mx-central-1, ca-west-1, cn-north-1, cn-northwest-1'
 
 env:
-  COMMERCIAL_REGIONS: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
+  # Legacy list of commercial regions to deploy to. New regions should NOT be added here, and instead should be added to the `aws_region` default input to the workflow.
+  LEGACY_COMMERCIAL_REGIONS: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
   LAYER_NAME: AWSOpenTelemetryDistroDotNet
 
 permissions:
@@ -60,21 +61,21 @@ jobs:
     steps:
       - name: role arn
         env:
-          COMMERCIAL_REGIONS: ${{ env.COMMERCIAL_REGIONS }}
+          LEGACY_COMMERCIAL_REGIONS: ${{ env.LEGACY_COMMERCIAL_REGIONS }}
         run: |
-          COMMERCIAL_REGIONS_ARRAY=(${COMMERCIAL_REGIONS//,/ })
+          LEGACY_COMMERCIAL_REGIONS_ARRAY=(${LEGACY_COMMERCIAL_REGIONS//,/ })
           FOUND=false
-          for REGION in "${COMMERCIAL_REGIONS_ARRAY[@]}"; do
+          for REGION in "${LEGACY_COMMERCIAL_REGIONS_ARRAY[@]}"; do
             if [[ "$REGION" == "${{ matrix.aws_region }}" ]]; then
               FOUND=true
               break
             fi
           done
           if [ "$FOUND" = true ]; then
-            echo "Found ${{ matrix.aws_region }} in COMMERCIAL_REGIONS"
+            echo "Found ${{ matrix.aws_region }} in LEGACY_COMMERCIAL_REGIONS"
             SECRET_KEY="LAMBDA_LAYER_RELEASE"
           else
-            echo "Not found ${{ matrix.aws_region }} in COMMERCIAL_REGIONS"
+            echo "Not found ${{ matrix.aws_region }} in LEGACY_COMMERCIAL_REGIONS"
             SECRET_KEY="${{ matrix.aws_region }}_LAMBDA_LAYER_RELEASE"
           fi
           SECRET_KEY=${SECRET_KEY//-/_}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/aws-otel-python-instrumentation/pull/458

*Description of changes:*

1.    Rename COMMERCIAL_REGIONS to LEGACY_COMMERCIAL_REGIONS
1.    Add comments for clarity


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
