### PR TITLE
Remove `continue-on-error` in e2e and release workflows

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -61,7 +61,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs: 
       short_sha: ${{ steps.short_sha.outputs.SHORT_SHA }}
-    continue-on-error: true
     strategy:
       matrix:
         include:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -150,7 +150,6 @@ jobs:
     # since deleting from Private ECR is not possible.
     needs: [release, build-release-nuget]
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         include:


### PR DESCRIPTION
*Description of changes:*
Removes unintentional `continue-on-error` in `application-signals-e2e-test` and `release-build` workflows

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

