### PR TITLE
Ensure all steps in Image Scan runs 

### DIFF
--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -76,7 +76,6 @@ runs:
 
     - name: Scan x64 image
       if: runner.os == 'Linux'
-      continue-on-error: true
       shell: bash
       run: |
         echo "Simulating x64 scan failure"
@@ -84,7 +83,6 @@ runs:
 
     - name: Scan arm64 image
       if: runner.os == 'Linux'
-      continue-on-error: true
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}-arm64
@@ -94,7 +92,6 @@ runs:
 
     - name: Scan Windows image
       if: runner.os == 'Windows'
-      continue-on-error: true
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -67,7 +67,6 @@ runs:
         cp THIRD-PARTY-LICENSES ./arm64/THIRD-PARTY-LICENSES
         cd ./arm64
         docker build --platform linux/arm64 -t ${{ inputs.image-name }}-arm64 -f ../Dockerfile.linux .
-        exit 1
 
     - name: Build Windows container
       if: runner.os == 'Windows'
@@ -77,12 +76,10 @@ runs:
 
     - name: Scan x64 image
       if: always() && runner.os == 'Linux'
-      uses: ./.github/actions/image_scan
-      with:
-        image-ref: ${{ inputs.image-name }}-amd64
-        severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
-        logout: 'false'
-        skip-dirs: '/usr/share/dotnet,/usr/share/powershell'
+      shell: bash
+      run: |
+        echo "Simulating x64 scan failure"
+        exit 1
 
     - name: Scan arm64 image
       if: always() && runner.os == 'Linux'

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -75,14 +75,16 @@ runs:
         docker build -t ${{ inputs.image-name }} -f ./Dockerfile.windows2022 .
 
     - name: Scan x64 image
-      if: always() && runner.os == 'Linux'
+      if: runner.os == 'Linux'
+      continue-on-error: true
       shell: bash
       run: |
         echo "Simulating x64 scan failure"
         exit 1
 
     - name: Scan arm64 image
-      if: always() && runner.os == 'Linux'
+      if: runner.os == 'Linux'
+      continue-on-error: true
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}-arm64
@@ -91,7 +93,8 @@ runs:
         skip-dirs: '/usr/share/dotnet,/usr/share/powershell'
 
     - name: Scan Windows image
-      if: always() && runner.os == 'Windows'
+      if: runner.os == 'Windows'
+      continue-on-error: true
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -67,6 +67,7 @@ runs:
         cp THIRD-PARTY-LICENSES ./arm64/THIRD-PARTY-LICENSES
         cd ./arm64
         docker build --platform linux/arm64 -t ${{ inputs.image-name }}-arm64 -f ../Dockerfile.linux .
+        exit 1
 
     - name: Build Windows container
       if: runner.os == 'Windows'
@@ -75,7 +76,7 @@ runs:
         docker build -t ${{ inputs.image-name }} -f ./Dockerfile.windows2022 .
 
     - name: Scan x64 image
-      if: runner.os == 'Linux'
+      if: always() && runner.os == 'Linux'
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}-amd64
@@ -84,7 +85,7 @@ runs:
         skip-dirs: '/usr/share/dotnet,/usr/share/powershell'
 
     - name: Scan arm64 image
-      if: runner.os == 'Linux'
+      if: always() && runner.os == 'Linux'
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}-arm64
@@ -93,7 +94,7 @@ runs:
         skip-dirs: '/usr/share/dotnet,/usr/share/powershell'
 
     - name: Scan Windows image
-      if: runner.os == 'Windows'
+      if: always() && runner.os == 'Windows'
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image-name }}

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -76,10 +76,12 @@ runs:
 
     - name: Scan x64 image
       if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        echo "Simulating x64 scan failure"
-        exit 1
+      uses: ./.github/actions/image_scan
+      with:
+        image-ref: ${{ inputs.image-name }}-amd64
+        severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+        logout: 'false'
+        skip-dirs: '/usr/share/dotnet,/usr/share/powershell'
 
     - name: Scan arm64 image
       if: runner.os == 'Linux'

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: ${{ inputs.environment }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: windows-2022

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: ${{ inputs.environment }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-2022
@@ -153,6 +154,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: ${{ inputs.environment }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022, ubuntu-latest]
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: windows-2022

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-2022
@@ -132,6 +133,7 @@ jobs:
     needs: [build, build-arm, build-x64-musl, build-arm-musl]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-2022

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -145,7 +145,7 @@ jobs:
             layer_artifact/layer.zip.sha256 \
             --clobber
 
-  release-image:
+  build-and-scan-images:
     # We want to build and release nuget first so that if it fails, it fails before publishing to private ECR
     # since deleting from Private ECR is not possible.
     needs: [release, build-release-nuget]
@@ -159,9 +159,31 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build and scan Linux images
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/build-and-scan-image
+        with:
+          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
+      - name: Build and scan Windows image
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/build-and-scan-image
+        with:
+          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
 
-
+  release-image:
+    # Only push images if ALL build and scan jobs succeed
+    needs: [build-and-scan-images]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+          - os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
       - name: Configure AWS credentials for public ECR
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -190,18 +212,6 @@ jobs:
       - name: Login to Amazon private ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Build and scan Linux images
-        if: runner.os == 'Linux'
-        uses: ./.github/actions/build-and-scan-image
-        with:
-          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
-
-      - name: Build and scan Windows image
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/build-and-scan-image
-        with:
-          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
 
       - name: Push Linux x64 Image
         if: runner.os == 'Linux'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -145,13 +145,12 @@ jobs:
             layer_artifact/layer.zip.sha256 \
             --clobber
 
-  build-and-scan-images:
+  release-image:
     # We want to build and release nuget first so that if it fails, it fails before publishing to private ECR
     # since deleting from Private ECR is not possible.
     needs: [release, build-release-nuget]
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: windows-2022
@@ -159,31 +158,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build and scan Linux images
-        if: runner.os == 'Linux'
-        uses: ./.github/actions/build-and-scan-image
-        with:
-          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
-      - name: Build and scan Windows image
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/build-and-scan-image
-        with:
-          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
 
-  release-image:
-    # Only push images if ALL build and scan jobs succeed
-    needs: [build-and-scan-images]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-2022
-          - os: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      
+
       - name: Configure AWS credentials for public ECR
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -212,6 +189,18 @@ jobs:
       - name: Login to Amazon private ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and scan Linux images
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/build-and-scan-image
+        with:
+          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
+
+      - name: Build and scan Windows image
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/build-and-scan-image
+        with:
+          image-name: ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}-windows2022
 
       - name: Push Linux x64 Image
         if: runner.os == 'Linux'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -151,6 +151,7 @@ jobs:
     needs: [release, build-release-nuget]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-2022


### PR DESCRIPTION
*Description of changes:*
Disabling fail fast to ensure we all image scan jobs get run regardless of failure of one image scan.
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast

Note:
We can't move the build step from the release-image job because GitHub Actions jobs run on isolated runners - Docker images built in one job aren't available to another job

We can't add fail-fast: false to the release workflow because we need ALL image scans to pass before any images are published - if any scan fails, the entire release should be blocked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

