### PR TITLE
updating 3p actions from VID to CSHA

### DIFF
--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -9,35 +9,35 @@ runs:
   steps:
     - name: Download Linux x64 Artifact
       if: runner.os == 'Linux'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
       with:
         name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
         path: ./artifacts/linux/x64
 
     - name: Download Linux x64 MUSL Artifact
       if: runner.os == 'Linux'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
       with:
         name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
         path: ./artifacts/linux/x64-musl
 
     - name: Download Linux arm64 Artifact
       if: runner.os == 'Linux'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
       with:
         name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
         path: ./artifacts/linux/arm64
 
     - name: Download Linux arm64 MUSL Artifact
       if: runner.os == 'Linux'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
       with:
         name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
         path: ./artifacts/linux/arm64-musl
 
     - name: Download Windows Artifact
       if: runner.os == 'Windows'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
       with:
         name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
         path: ./artifacts/windows

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -38,17 +38,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.STAING_ARTIFACTS_ACCESS_ROLE }}
           role-external-id: ApplicationSignalsDotnet
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: ${{ inputs.ec2-default-image-name }}
       
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: ${{ inputs.ec2-windows-image-name }}
 
@@ -67,7 +67,7 @@ jobs:
           - os: windows-2022
           - os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Get Short SHA
         id: short_sha
         run: |
@@ -76,7 +76,7 @@ jobs:
         shell: bash
 
       - name: Configure AWS credentials for private ECR
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME}}
           aws-region: us-east-1
@@ -88,14 +88,14 @@ jobs:
         
       - name: Download Linux x64 Artifact
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: ./artifacts/linux/x64
           
       - name: Download Windows Artifact
         if: runner.os == 'Windows'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: ./artifacts/windows
@@ -196,17 +196,17 @@ jobs:
   build-lambda-staging-sample-app:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.STAING_ARTIFACTS_ACCESS_ROLE }}
           role-external-id: ApplicationSignalsDotnet
           aws-region: us-east-1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,17 +61,17 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0 
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
     # or others). This is typically only required for manual builds.
     # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+    #   uses: actions/setup-example@v1 
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -99,6 +99,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -19,23 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo for dependency scan
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
       - name: Install java for dependency scan
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           java-version: 17
           distribution: 'temurin'
 
       - name: Configure AWS credentials for dependency scan
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.SECRET_MANAGER_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -74,7 +74,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Login to Public ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: public.ecr.aws
           
@@ -98,7 +98,7 @@ jobs:
 
       - name: Configure AWS Credentials for emitting metrics
         if: always()
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -30,10 +30,10 @@ jobs:
           - os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -55,28 +55,28 @@ jobs:
 
       - name: Upload Artifact on X64 Linux
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
       
       - name: Upload bash installation script
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-otel-dotnet-install.sh
           path: bin/InstallationScripts/aws-otel-dotnet-install.sh
 
       - name: Upload psm1 installation script
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: AWS.Otel.DotNet.Auto.psm1
           path: bin/InstallationScripts/AWS.Otel.DotNet.Auto.psm1
 
       - name: Upload Artifact on Windows
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
@@ -86,7 +86,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
             /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
 
       - name: Upload Artifact on MUSL X64 Linux
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
@@ -107,10 +107,10 @@ jobs:
     runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
     environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -121,7 +121,7 @@ jobs:
         run: dotnet test
 
       - name: Upload Artifact on arm64 Linux
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
@@ -131,7 +131,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
@@ -143,7 +143,7 @@ jobs:
             /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
 
       - name: Upload Artifact on MUSL arm64 Linux
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
@@ -157,7 +157,7 @@ jobs:
       matrix:
         os: [windows-2022, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Build and scan Linux images
         if: runner.os == 'Linux'
@@ -187,7 +187,7 @@ jobs:
     if: always()
     steps:
       - name: Configure AWS Credentials for emitting metrics
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,7 +19,7 @@ jobs:
   changelog-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
           
@@ -61,10 +61,10 @@ jobs:
           - os: ubuntu-latest
           - os: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -94,14 +94,14 @@ jobs:
 
       - name: Upload Artifact on X64 Linux
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
 
       - name: Upload Artifact on Windows
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-windows.zip
@@ -109,10 +109,10 @@ jobs:
   build-arm:
     runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -123,7 +123,7 @@ jobs:
         run: dotnet test
 
       - name: Upload Artifact on arm64 Linux
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
@@ -144,7 +144,7 @@ jobs:
             /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
 
       - name: Upload Artifact on MUSL X64 Linux
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
@@ -153,7 +153,7 @@ jobs:
     runs-on: codebuild-adot-dotnet-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
@@ -165,7 +165,7 @@ jobs:
             /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
 
       - name: Upload Artifact on MUSL arm64 Linux
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
           path: bin/aws-distro-opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
@@ -180,7 +180,7 @@ jobs:
           - os: windows-2022
           - os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Build and scan Linux images
         if: runner.os == 'Linux'
@@ -198,14 +198,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/udp-exporter-e2e-test.yml
+++ b/.github/workflows/udp-exporter-e2e-test.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: Set up .NET CLI
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d #v5.0.0
         with:
           dotnet-version: '8.0.x'
 
       - name: Configure AWS credentials for Testing Tracing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.XRAY_UDP_EXPORTER_TEST_ROLE }}
           aws-region: 'us-east-1'

--- a/.github/workflows/unlist-nuget.yml
+++ b/.github/workflows/unlist-nuget.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Assume nuget role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.NUGET_ACCESS_ROLE_ARN }}
           aws-region: ${{ env.AWS_SIGNING_KEY_REGION }}


### PR DESCRIPTION
This pr updates *non-release* workflows and actions 3p actions using version ID to use commit SHA.

References
https://github.com/aws-actions/configure-aws-credentials     
https://github.com/actions/download-artifact
https://github.com/github/codeql-action
https://github.com/docker/login-action
https://github.com/actions/upload-artifact
https://github.com/docker/setup-buildx-action
https://github.com/docker/setup-qemu-action
https://github.com/actions/download-artifact
https://github.com/github/codeql-action
https://github.com/actions/setup-dotnet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

