### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,8 @@
 # supported CodeQL languages.
 #
 name: "CodeQL Advanced"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-observability/aws-otel-dotnet-instrumentation/security/code-scanning/9](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/security/code-scanning/9)

To fix the problem, add an explicit `permissions` block to restrict the GITHUB_TOKEN's access in the workflow. For CodeQL analysis and especially for the `all-codeql-checks-pass` job, the minimum required is usually `contents: read`, which allows only reading repository contents. You can add the `permissions` block either at the workflow root or at the job level. As the CodeQL workflow may include jobs with different privilege requirements, the best approach is to set the default at workflow root (applies to all jobs unless overridden) with `contents: read`, and add further privileges at the job level only if later needed. Edit the file `.github/workflows/codeql.yml` by inserting the following after the `name:` field at the top:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required, as this is a YAML settings change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
