### PR TITLE
feat: allow HTTP operations to be configurable via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ For any change that affects end users of this package, please add an entry under
   ([#137](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/137))
 
 If your change does not need a CHANGELOG entry, add the "skip changelog" label to your PR.
+
 ## Unreleased
+- Support environment-configured endpoint visibility for HTTP operation names
+  ([#392](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/392))
 
 ## v1.12.0 - 2026-03-19
 - KafkaEvent input type support for Lambda and Task<unit> return type serialization issue fix for f#

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanMetricsProcessor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanMetricsProcessor.cs
@@ -74,6 +74,10 @@ public class AwsSpanMetricsProcessor : BaseProcessor<Activity>
     /// <param name="activity"><see cref="Activity"/> to configure</param>
     public override void OnEnd(Activity activity)
     {
+        // If OTEL_AWS_HTTP_OPERATION_PATHS is configured, override the span name so that
+        // metrics use the configured operation path instead of the original span name.
+        AwsSpanProcessingUtil.ApplyOperationPathSpanName(activity);
+
         Dictionary<string, ActivityTagsCollection> attributeDictionary =
             this.generator.GenerateMetricAttributeMapFromSpan(activity, this.resource);
 

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -66,11 +66,17 @@ internal sealed class AwsSpanProcessingUtil
 
     internal static readonly string SqlDialectPattern = "^(?:" + string.Join("|", GetDialectKeywords()) + ")\\b";
 
+    // Environment variable for configurable operation name paths
+    internal static readonly string OtelAwsHttpOperationPathsConfig = "OTEL_AWS_HTTP_OPERATION_PATHS";
+
     private static readonly string HttpRouteDataParsingEnabledConfig = "HTTP_ROUTE_DATA_PARSING_ENABLED";
     private static readonly string HttpRouteDataParsingEnabled = System.Environment.GetEnvironmentVariable(HttpRouteDataParsingEnabledConfig) ?? "false";
 
     private static readonly string AwsLambdaFunctionNameConfig = "AWS_LAMBDA_FUNCTION_NAME";
     private static readonly string? AwsLambdaFunctionName = Environment.GetEnvironmentVariable(AwsLambdaFunctionNameConfig);
+
+    // Cached parsed operation paths (sorted longest first)
+    private static List<string>? operationPaths;
 
     internal static List<string> GetDialectKeywords()
     {
@@ -103,6 +109,151 @@ internal sealed class AwsSpanProcessingUtil
         {
             return new List<string>();
         }
+    }
+
+    /// <summary>
+    /// Parse the OTEL_AWS_HTTP_OPERATION_PATHS env var into a sorted list of path templates
+    /// (longest first by segment count). Returns an empty list if the env var is not set.
+    /// </summary>
+    internal static List<string> GetOperationPaths()
+    {
+        if (operationPaths == null)
+        {
+            string? config = Environment.GetEnvironmentVariable(OtelAwsHttpOperationPathsConfig);
+            if (string.IsNullOrWhiteSpace(config))
+            {
+                operationPaths = new List<string>();
+            }
+            else
+            {
+                var paths = config.Split(',')
+                    .Select(p => p.Trim())
+                    .Where(p => p.Length > 0)
+                    .ToList();
+
+                // Sort longest first (by segment count) for longest-prefix-match.
+                // For patterns with the same number of segments, original config order is preserved (stable sort).
+                paths.Sort((a, b) => b.Split('/').Length.CompareTo(a.Split('/').Length));
+                operationPaths = paths;
+            }
+        }
+
+        return operationPaths;
+    }
+
+    /// <summary>Reset cached operation paths (for testing).</summary>
+    internal static void ResetOperationPaths()
+    {
+        operationPaths = null;
+    }
+
+    /// <summary>
+    /// If OTEL_AWS_HTTP_OPERATION_PATHS is configured and a pattern matches the span's URL path,
+    /// mutates the span's DisplayName to "METHOD /path/template". Returns the span unchanged if
+    /// no config is set or no pattern matches.
+    /// </summary>
+    internal static Activity ApplyOperationPathSpanName(Activity span)
+    {
+        var paths = GetOperationPaths();
+        if (paths.Count == 0)
+        {
+            return span;
+        }
+
+        string? urlPath = GetUrlPath(span);
+        if (string.IsNullOrEmpty(urlPath))
+        {
+            return span;
+        }
+
+        // Strip query string and fragment (relevant for http.target)
+        foreach (char sep in new[] { '?', '#' })
+        {
+            int idx = urlPath.IndexOf(sep);
+            if (idx >= 0)
+            {
+                urlPath = urlPath.Substring(0, idx);
+            }
+        }
+
+        // Normalize trailing slashes
+        while (urlPath.EndsWith("/") && urlPath.Length > 1)
+        {
+            urlPath = urlPath.Substring(0, urlPath.Length - 1);
+        }
+
+        string[] urlSegments = urlPath.Split('/');
+        foreach (string pattern in paths)
+        {
+            string normalizedPattern = pattern;
+            while (normalizedPattern.EndsWith("/") && normalizedPattern.Length > 1)
+            {
+                normalizedPattern = normalizedPattern.Substring(0, normalizedPattern.Length - 1);
+            }
+
+            if (SegmentsMatch(urlSegments, normalizedPattern.Split('/')))
+            {
+                string? httpMethod = GetHttpMethod(span);
+                string newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
+                span.DisplayName = newName;
+                return span;
+            }
+        }
+
+        return span;
+    }
+
+    /// <summary>Return the URL path from server span attributes, preferring url.path over http.target.</summary>
+    private static string? GetUrlPath(Activity span)
+    {
+        return (string?)span.GetTagItem(AttributeUrlPath) ?? (string?)span.GetTagItem(AttributeHttpTarget);
+    }
+
+    /// <summary>Get the HTTP method from the span, checking new and deprecated semconv attributes.</summary>
+    private static string? GetHttpMethod(Activity span)
+    {
+        return (string?)span.GetTagItem(AttributeHttpRequestMethod) ?? (string?)span.GetTagItem(AttributeHttpMethod);
+    }
+
+    /// <summary>
+    /// Check if URL segments match a pattern's segments. Only pattern segments can be wildcards
+    /// ({param}, :param, or *). The pattern acts as a prefix — extra URL segments are allowed.
+    /// </summary>
+    private static bool SegmentsMatch(string[] urlSegments, string[] patternSegments)
+    {
+        for (int i = 0; i < patternSegments.Length; i++)
+        {
+            if (i >= urlSegments.Length)
+            {
+                return false;
+            }
+
+            string ps = patternSegments[i];
+            string us = urlSegments[i];
+
+            if (IsWildcardSegment(ps))
+            {
+                if (string.IsNullOrEmpty(us))
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (ps != us)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>A segment is a wildcard if it uses {param}, :param, or * format.</summary>
+    private static bool IsWildcardSegment(string segment)
+    {
+        return (segment.StartsWith("{") && segment.EndsWith("}")) || segment.StartsWith(":") || segment == "*";
     }
 
     // Ingress operation (i.e. operation for Server and Consumer spans) will be generated from
@@ -352,10 +503,10 @@ internal sealed class AwsSpanProcessingUtil
             return false;
         }
 
-        if (IsKeyPresent(span, AttributeHttpRequestMethod))
+        string? httpMethod = GetHttpMethod(span);
+        if (httpMethod != null)
         {
-            object? httpMethod = span.GetTagItem(AttributeHttpRequestMethod);
-            return !operation.Equals((string?)httpMethod);
+            return !operation.Equals(httpMethod);
         }
 
         return true;

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -203,59 +203,6 @@ internal sealed class AwsSpanProcessingUtil
         return span;
     }
 
-    /// <summary>Return the URL path from server span attributes, preferring url.path over http.target.</summary>
-    private static string? GetUrlPath(Activity span)
-    {
-        return (string?)span.GetTagItem(AttributeUrlPath) ?? (string?)span.GetTagItem(AttributeHttpTarget);
-    }
-
-    /// <summary>Get the HTTP method from the span, checking new and deprecated semconv attributes.</summary>
-    private static string? GetHttpMethod(Activity span)
-    {
-        return (string?)span.GetTagItem(AttributeHttpRequestMethod) ?? (string?)span.GetTagItem(AttributeHttpMethod);
-    }
-
-    /// <summary>
-    /// Check if URL segments match a pattern's segments. Only pattern segments can be wildcards
-    /// ({param}, :param, or *). The pattern acts as a prefix — extra URL segments are allowed.
-    /// </summary>
-    private static bool SegmentsMatch(string[] urlSegments, string[] patternSegments)
-    {
-        for (int i = 0; i < patternSegments.Length; i++)
-        {
-            if (i >= urlSegments.Length)
-            {
-                return false;
-            }
-
-            string ps = patternSegments[i];
-            string us = urlSegments[i];
-
-            if (IsWildcardSegment(ps))
-            {
-                if (string.IsNullOrEmpty(us))
-                {
-                    return false;
-                }
-
-                continue;
-            }
-
-            if (ps != us)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /// <summary>A segment is a wildcard if it uses {param}, :param, or * format.</summary>
-    private static bool IsWildcardSegment(string segment)
-    {
-        return (segment.StartsWith("{") && segment.EndsWith("}")) || segment.StartsWith(":") || segment == "*";
-    }
-
     // Ingress operation (i.e. operation for Server and Consumer spans) will be generated from
     // "http.method + http.target/with the first API path parameter" if the default span name equals
     // null, UnknownOperation or http.method value.
@@ -457,6 +404,52 @@ internal sealed class AwsSpanProcessingUtil
     // TODO: Verify this after AWS SDK AutoInstrumentation
     // Can also use this instead to check the service name
     // https://opentelemetry.io/docs/specs/semconv/cloud-providers/aws-sdk/
+    private static string? GetUrlPath(Activity span)
+    {
+        return (string?)span.GetTagItem(AttributeUrlPath) ?? (string?)span.GetTagItem(AttributeHttpTarget);
+    }
+
+    private static string? GetHttpMethod(Activity span)
+    {
+        return (string?)span.GetTagItem(AttributeHttpRequestMethod) ?? (string?)span.GetTagItem(AttributeHttpMethod);
+    }
+
+    private static bool SegmentsMatch(string[] urlSegments, string[] patternSegments)
+    {
+        for (int i = 0; i < patternSegments.Length; i++)
+        {
+            if (i >= urlSegments.Length)
+            {
+                return false;
+            }
+
+            string ps = patternSegments[i];
+            string us = urlSegments[i];
+
+            if (IsWildcardSegment(ps))
+            {
+                if (string.IsNullOrEmpty(us))
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (ps != us)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsWildcardSegment(string segment)
+    {
+        return (segment.StartsWith("{") && segment.EndsWith("}")) || segment.StartsWith(":") || segment == "*";
+    }
+
     private static bool IsSqsReceiveMessageConsumerSpan(Activity span)
     {
         string? messagingOperation = (string?)span.GetTagItem(AttributeMessagingOperation);

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -167,22 +167,23 @@ internal sealed class AwsSpanProcessingUtil
         }
 
         // Strip query string and fragment (relevant for http.target)
+        string path = urlPath!;
         foreach (char sep in new[] { '?', '#' })
         {
-            int idx = urlPath.IndexOf(sep);
+            int idx = path.IndexOf(sep);
             if (idx >= 0)
             {
-                urlPath = urlPath.Substring(0, idx);
+                path = path.Substring(0, idx);
             }
         }
 
         // Normalize trailing slashes
-        while (urlPath.EndsWith("/") && urlPath.Length > 1)
+        while (path.EndsWith("/") && path.Length > 1)
         {
-            urlPath = urlPath.Substring(0, urlPath.Length - 1);
+            path = path.Substring(0, path.Length - 1);
         }
 
-        string[] urlSegments = urlPath.Split('/');
+        string[] urlSegments = path.Split('/');
         foreach (string pattern in paths)
         {
             string normalizedPattern = pattern;

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsSpanProcessingUtilTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsSpanProcessingUtilTest.cs
@@ -526,4 +526,233 @@ public class AwsSpanProcessingUtilTest
             Assert.True(keyword.Length <= AwsSpanProcessingUtil.MaxKeywordLength);
         }
     }
+
+    // --- Tests for OTEL_AWS_HTTP_OPERATION_PATHS and ApplyOperationPathSpanName ---
+    [Fact]
+    public void TestApplyOperationPathMatchesUrlPath()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests/{id}/leaderboard,/api/contests/{id},/api/contests");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/contests/123/leaderboard");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/contests/{id}/leaderboard", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathFallsBackToHttpTarget()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/teams/{id},/api/teams");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeHttpTarget, "/api/teams/5?include=roster");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/teams/{id}", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathLongestMatchWins()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests/{id}/leaderboard,/api/contests/{id},/api/contests,/api");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/contests/42");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/contests/{id}", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathSameLengthFirstConfigWins()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/v1/{userId},/api/{version}/user1");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/v1/user1");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/v1/{userId}", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathNoMatchReturnsOriginal()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests/{id}");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /unknown", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/unknown/path");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /unknown", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathEmptyConfigReturnsOriginal()
+    {
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+        var result = AwsSpanProcessingUtil.ApplyOperationPathSpanName(span!);
+        Assert.Equal(span, result);
+    }
+
+    [Fact]
+    public void TestApplyOperationPathNoHttpMethod()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("/api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/contests");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("/api/contests", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathTrailingSlashNormalized()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/contests/");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/contests", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathQueryStringStripped()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/contests?page=1&size=10");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/contests", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathColonParamWildcard()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/users/:userId/stats");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/users/42/stats");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/users/:userId/stats", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathStarWildcard()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/*/users/*");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/v2/users/42");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api/*/users/*", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+
+    [Fact]
+    public void TestApplyOperationPathPatternLongerThanUrl()
+    {
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests/{id}");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            using var span = this.testSource.StartActivity("GET /api", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            AwsSpanProcessingUtil.ApplyOperationPathSpanName(span);
+            Assert.Equal("GET /api", span.DisplayName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Same as https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1352

When HTTP span names don't contain a URL path, we generate the HTTP operation by truncating the URL path to only the first trailing value to preserve low cardinality (i.e. /api/v1/users -> /api). This can result in overly broad operation groupings for services with endpoint paths of various depths.

This PR introduces an environment variable configuration, `OTEL_AWS_HTTP_OPERATION_PATHS`, which allows users to configure their own HTTP endpoint paths. If this variable is provided, the span name's URL path will resolve to the longest matching path. Wildcards are supported with the following syntaxes: `{version}`, `:version`, or simply `*`. This way, users can decide how their service endpoint are grouped into operation names shown in CloudWatch.

Added unit tests to verify behavior, and did some E2E testing with an instrumented HTTP server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

