### PR TITLE
Upgrade Claude Code review to Opus 4.7 with scoped tool permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,6 @@ jobs:
           direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-7-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
+            --model us.anthropic.claude-opus-4-7 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,6 @@ jobs:
           direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/*/reviews*)"
+            --model us.anthropic.claude-opus-4-7-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
-            Review this PR for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines.
+            Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@1b422b3517b51140e4484faab676c5e68b914866 #v1.0.73
+        uses: anthropics/claude-code-action@0766301cba8671db92e3025984e2fd038ad48ff7 #v1.0.104
         with:
           use_bedrock: "true"
           direct_api: "true"


### PR DESCRIPTION
## Summary
- Upgrades the Claude Code review model from Opus 4.6 to Opus 4.7
- Scopes `allowedTools` patterns to the current PR number instead of wildcards. This prevents Claude from accidentally posting review comments on other PRs (e.g. previously merged PRs).
- Adds an explicit prompt guardrail telling Claude to only interact with the current PR

## Context
On aws-otel-js-instrumentation, a review run for PR #406 accidentally posted 10 review comments on the already-merged PR #391. The cause was the wildcard pattern in `allowedTools` (`repos/*/pulls/*`) allowing Claude to post to any PR.

## Test plan
- [ ] Verify Claude still posts review comments on new PRs
- [ ] Verify Claude cannot post to other PRs (by checking only current PR gets comments)