### PR TITLE
Fix Claude Code review allowedTools to accept flags

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,6 @@ jobs:
           direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-7 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}*),Bash(gh pr view ${{ github.event.pull_request.number }}*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
+            --model us.anthropic.claude-opus-4-7 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,6 @@ jobs:
           direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-7 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
+            --model us.anthropic.claude-opus-4-7 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}*),Bash(gh pr view ${{ github.event.pull_request.number }}*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.


### PR DESCRIPTION
## Summary
- Adds trailing wildcards (`*`) to the Claude Code review `allowedTools` patterns so `gh pr diff NNN` and `gh pr view NNN` commands with flags (e.g. `--json`, `--web`) are still allowed
- Without the wildcard, `Bash(gh pr view 394)` only matched the literal string `gh pr view 394` and would deny any invocation with flags like `gh pr view 394 --json number,title,...`, causing Claude to burn through turns on repeated permission denials until hitting the 15-min timeout

## Security
Trailing wildcard is still scoped to the current PR number via `${{ github.event.pull_request.number }}`, so Claude cannot access other PRs. For example `Bash(gh pr view 394*)` matches `gh pr view 394 --json ...` but NOT `gh pr view 391`.

## Test plan
- [ ] Verify Claude review runs complete faster (not hitting timeout) on new PRs
- [ ] Verify Claude still cannot read/post to other PR numbers