### PR TITLE
Add SigV4-signed OTLP log exporter for CloudWatch Logs endpoint

### DIFF
--- a/exporters/AWS.Distro.OpenTelemetry.Exporter.Xray.Udp/OtlpExporterUtils.cs
+++ b/exporters/AWS.Distro.OpenTelemetry.Exporter.Xray.Udp/OtlpExporterUtils.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using AWS.Distro.OpenTelemetry.AutoInstrumentation.Logging;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
 
 namespace AWS.Distro.OpenTelemetry.Exporter.Xray.Udp;
@@ -16,11 +17,15 @@ public class OtlpExporterUtils
     private static readonly ILogger Logger = Factory.CreateLogger<OtlpExporterUtils>();
 
     private static readonly MethodInfo? WriteTraceDataMethod;
+    private static readonly MethodInfo? WriteLogsDataMethod;
     private static readonly object? SdkLimitOptions;
+    private static readonly object? ExperimentalOptions;
 
     static OtlpExporterUtils() {
         Type? otlpSerializerType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer.ProtobufOtlpTraceSerializer, OpenTelemetry.Exporter.OpenTelemetryProtocol");
+        Type? otlpLogSerializerType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer.ProtobufOtlpLogSerializer, OpenTelemetry.Exporter.OpenTelemetryProtocol");
         Type? sdkLimitOptionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.SdkLimitOptions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
+        Type? experimentalOptionsType = Type.GetType("OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExperimentalOptions, OpenTelemetry.Exporter.OpenTelemetryProtocol");
 
         if (sdkLimitOptionsType == null)
         {
@@ -38,7 +43,7 @@ public class OtlpExporterUtils
             "WriteTraceData",
             BindingFlags.NonPublic | BindingFlags.Static,
             null,
-            new[] 
+            new[]
             {
                 typeof(byte[]).MakeByRefType(),    // ref byte[] buffer
                 typeof(int),                       // int writePosition
@@ -47,7 +52,21 @@ public class OtlpExporterUtils
                 typeof(Batch<Activity>).MakeByRefType() // in Batch<Activity>
             },
             null)
-            ?? throw new MissingMethodException("WriteTraceData not found");  // :contentReference[oaicite:1]{index=1}
+            ?? throw new MissingMethodException("WriteTraceData not found");
+
+        if (otlpLogSerializerType != null)
+        {
+            WriteLogsDataMethod = otlpLogSerializerType.GetMethod(
+                "WriteLogsData",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                experimentalOptionsType != null
+                    ? new[] { typeof(byte[]).MakeByRefType(), typeof(int), sdkLimitOptionsType, experimentalOptionsType, typeof(Resource), typeof(Batch<LogRecord>).MakeByRefType() }
+                    : new[] { typeof(byte[]).MakeByRefType(), typeof(int), sdkLimitOptionsType, typeof(Resource), typeof(Batch<LogRecord>).MakeByRefType() },
+                null);
+
+            ExperimentalOptions = experimentalOptionsType != null ? Activator.CreateInstance(experimentalOptionsType) : null;
+        }
 
         SdkLimitOptions = GetSdkLimitOptions();
     }
@@ -77,6 +96,27 @@ public class OtlpExporterUtils
         // Unpack ref-buffer
         buffer = (byte[])args[0];
 
+        return result;
+    }
+
+
+    public static int WriteLogsData(
+        ref byte[] buffer,
+        int writePosition,
+        Resource? resource,
+        in Batch<LogRecord> batch)
+    {
+        if (SdkLimitOptions == null || WriteLogsDataMethod == null)
+        {
+            return -1;
+        }
+
+        object[] args = ExperimentalOptions != null && WriteLogsDataMethod.GetParameters().Length == 6
+            ? new object[] { buffer, writePosition, SdkLimitOptions, ExperimentalOptions, resource!, batch! }
+            : new object[] { buffer, writePosition, SdkLimitOptions, resource!, batch! };
+
+        var result = (int)WriteLogsDataMethod.Invoke(obj: null, parameters: args)!;
+        buffer = (byte[])args[0];
         return result;
     }
 

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -324,27 +324,6 @@ public class Plugin
         }
     }
 
-
-    private static Dictionary<string, string> ParseOtlpHeaders(string? headersString)
-    {
-        var headers = new Dictionary<string, string>();
-        if (string.IsNullOrEmpty(headersString))
-        {
-            return headers;
-        }
-
-        foreach (var pair in headersString.Split(','))
-        {
-            var parts = pair.Split('=', 2);
-            if (parts.Length == 2)
-            {
-                headers[parts[0].Trim()] = parts[1].Trim();
-            }
-        }
-
-        return headers;
-    }
-
     /// <summary>
     /// To configure Resource with resource detectors and <see cref="DistroAttributes"/>
     /// Check <see cref="ResourceBuilderCustomizer"/> for more information.
@@ -528,6 +507,26 @@ public class Plugin
             LogLevel.Debug, "AWS Application Signals export protocol: %{0}", options.Protocol);
         Logger.Log(
             LogLevel.Debug, "AWS Application Signals export endpoint: %{0}", options.Endpoint);
+    }
+
+    private static Dictionary<string, string> ParseOtlpHeaders(string? headersString)
+    {
+        var headers = new Dictionary<string, string>();
+        if (string.IsNullOrEmpty(headersString))
+        {
+            return headers;
+        }
+
+        foreach (var pair in headersString.Split(','))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length == 2)
+            {
+                headers[parts[0].Trim()] = parts[1].Trim();
+            }
+        }
+
+        return headers;
     }
 
     // This new function runs the sampler a second time after the needed attributes (such as UrlPath and HttpTarget)

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -517,9 +517,9 @@ public class Plugin
             return headers;
         }
 
-        foreach (var pair in headersString.Split(','))
+        foreach (var pair in headersString!.Split(','))
         {
-            var parts = pair.Split('=', 2);
+            var parts = pair.Split(new[] { '=' }, 2);
             if (parts.Length == 2)
             {
                 headers[parts[0].Trim()] = parts[1].Trim();

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -42,9 +42,11 @@ public class Plugin
     public static readonly string ApplicationSignalsEnabledConfig = "OTEL_AWS_APPLICATION_SIGNALS_ENABLED";
     internal static readonly string LambdaApplicationSignalsRemoteEnvironment = "LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT";
     private static readonly string XRayOtlpEndpointPattern = "^https://xray\\.([a-z0-9-]+)\\.amazonaws\\.com/v1/traces$";
+    private static readonly string CloudWatchLogsOtlpEndpointPattern = "^https://logs\\.([a-z0-9-]+)\\.amazonaws\\.com/v1/logs$";
     private static readonly string SigV4EnabledConfig = "OTEL_AWS_SIG_V4_ENABLED";
     private static readonly string TracesExporterConfig = "OTEL_TRACES_EXPORTER";
     private static readonly string OtelExporterOtlpTracesTimeout = "OTEL_EXPORTER_OTLP_TIMEOUT";
+    private static readonly string OtelExporterOtlpLogsEndpointConfig = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT";
     private static readonly int DefaultOtlpTracesTimeoutMilli = 10000;
 #pragma warning disable CS0436 // Type conflicts with imported type
     private static readonly ILoggerFactory Factory = LoggerFactory.Create(builder => builder.AddProvider(new ConsoleLoggerProvider()));
@@ -295,21 +297,52 @@ public class Plugin
     }
 
     /// <summary>
-    /// To configure logs SDK. In Lambda, replaces the default console exporter with
-    /// CompactConsoleLogRecordExporter for canonical JSON output on stdout.
-    /// The Lambda layer sets OTEL_LOGS_EXPORTER=none to suppress the upstream console exporter,
-    /// and this plugin registers our compact exporter as the sole log export path.
-    /// This mirrors Java's approach where customizeLogsExporter replaces SystemOutLogRecordExporter.
+    /// To configure logs SDK. In Lambda, registers CompactConsoleLogRecordExporter for console
+    /// output and a SigV4-signed OTLP exporter (via SimpleLogRecordExportProcessor for
+    /// synchronous flush before Lambda freezes the container).
     /// </summary>
     /// <param name="options">The OpenTelemetry logger options</param>
     public void ConfigureLogsOptions(global::OpenTelemetry.Logs.OpenTelemetryLoggerOptions options)
     {
-        if (AwsSpanProcessingUtil.IsLambdaEnvironment())
+        if (!AwsSpanProcessingUtil.IsLambdaEnvironment())
         {
-            Logger.Log(LogLevel.Debug, "Lambda environment detected, using CompactConsoleLogRecordExporter for logs.");
-            options.AddProcessor(new global::OpenTelemetry.SimpleLogRecordExportProcessor(
-                new AutoInstrumentation.Exporter.Console.Logs.CompactConsoleLogRecordExporter()));
+            return;
         }
+
+        options.AddProcessor(new global::OpenTelemetry.SimpleLogRecordExportProcessor(
+            new AutoInstrumentation.Exporter.Console.Logs.CompactConsoleLogRecordExporter()));
+
+        string? logsEndpoint = System.Environment.GetEnvironmentVariable(OtelExporterOtlpLogsEndpointConfig);
+        if (!string.IsNullOrEmpty(logsEndpoint) && System.Text.RegularExpressions.Regex.IsMatch(
+            logsEndpoint, CloudWatchLogsOtlpEndpointPattern))
+        {
+            string region = new Uri(logsEndpoint).Host.Split('.')[1];
+            var headers = ParseOtlpHeaders(System.Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_LOGS_HEADERS"));
+            var exporter = new SigV4OtlpLogExporter(new Uri(logsEndpoint), region, headers);
+            options.AddProcessor(new global::OpenTelemetry.SimpleLogRecordExportProcessor(exporter));
+            Logger.Log(LogLevel.Information, "Registered SigV4-signed OTLP log exporter for Lambda: {0}", logsEndpoint);
+        }
+    }
+
+
+    private static Dictionary<string, string> ParseOtlpHeaders(string? headersString)
+    {
+        var headers = new Dictionary<string, string>();
+        if (string.IsNullOrEmpty(headersString))
+        {
+            return headers;
+        }
+
+        foreach (var pair in headersString.Split(','))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length == 2)
+            {
+                headers[parts[0].Trim()] = parts[1].Trim();
+            }
+        }
+
+        return headers;
     }
 
     /// <summary>

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/SigV4OtlpLogExporter.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/SigV4OtlpLogExporter.cs
@@ -20,7 +20,8 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
 internal class SigV4OtlpLogExporter : BaseExporter<LogRecord>
 {
     private static readonly string ServiceName = "logs";
-    private readonly HttpClient client = new HttpClient();
+    private static readonly int DefaultTimeoutMilliseconds = 10000;
+    private readonly HttpClient client;
     private readonly Uri endpoint;
     private readonly string region;
     private readonly Dictionary<string, string> customHeaders;
@@ -31,10 +32,16 @@ internal class SigV4OtlpLogExporter : BaseExporter<LogRecord>
         this.endpoint = endpoint;
         this.region = region;
         this.customHeaders = customHeaders;
+        this.client = new HttpClient()
+        {
+            Timeout = TimeSpan.FromMilliseconds(GetTimeoutMilliseconds()),
+        };
     }
 
     public override ExportResult Export(in Batch<LogRecord> batch)
     {
+        using var scope = SuppressInstrumentationScope.Begin();
+
         if (this.resource == null && this.ParentProvider is LoggerProvider provider)
         {
             this.resource = provider.GetResource() ?? Resource.Empty;
@@ -99,6 +106,17 @@ internal class SigV4OtlpLogExporter : BaseExporter<LogRecord>
         {
             return ExportResult.Failure;
         }
+    }
+
+    private static int GetTimeoutMilliseconds()
+    {
+        string? timeout = System.Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_LOGS_TIMEOUT");
+        if (int.TryParse(timeout, out int result))
+        {
+            return result;
+        }
+
+        return DefaultTimeoutMilliseconds;
     }
 
     private class EmptyAmazonWebServiceRequest : AmazonWebServiceRequest

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/SigV4OtlpLogExporter.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/SigV4OtlpLogExporter.cs
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net.Http;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.XRay;
+using AWS.Distro.OpenTelemetry.Exporter.Xray.Udp;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// OTLP log exporter with SigV4 signing for CloudWatch Logs endpoint.
+/// </summary>
+internal class SigV4OtlpLogExporter : BaseExporter<LogRecord>
+{
+    private static readonly string ServiceName = "logs";
+    private readonly HttpClient client = new HttpClient();
+    private readonly Uri endpoint;
+    private readonly string region;
+    private readonly Dictionary<string, string> customHeaders;
+    private Resource? resource;
+
+    public SigV4OtlpLogExporter(Uri endpoint, string region, Dictionary<string, string> customHeaders)
+    {
+        this.endpoint = endpoint;
+        this.region = region;
+        this.customHeaders = customHeaders;
+    }
+
+    public override ExportResult Export(in Batch<LogRecord> batch)
+    {
+        if (this.resource == null && this.ParentProvider is LoggerProvider provider)
+        {
+            this.resource = provider.GetResource() ?? Resource.Empty;
+        }
+
+        byte[] serializedData = new byte[750000];
+        int length = OtlpExporterUtils.WriteLogsData(ref serializedData, 0, this.resource, batch);
+        if (length <= 0)
+        {
+            return ExportResult.Failure;
+        }
+
+        try
+        {
+            IRequest sigV4Request = new DefaultRequest(new EmptyAmazonWebServiceRequest(), ServiceName)
+            {
+                HttpMethod = "POST",
+                ContentStream = new MemoryStream(serializedData, 0, length),
+                Endpoint = this.endpoint,
+                SignatureVersion = SignatureVersion.SigV4,
+            };
+
+            var config = new AmazonXRayConfig()
+            {
+                AuthenticationRegion = this.region,
+                AuthenticationServiceName = ServiceName,
+                UseHttp = false,
+                ServiceURL = this.endpoint.AbsoluteUri,
+                RegionEndpoint = RegionEndpoint.GetBySystemName(this.region),
+            };
+
+            var credentials = FallbackCredentialsFactory.GetCredentials().GetCredentialsAsync().GetAwaiter().GetResult();
+
+            if (credentials.UseToken && credentials.Token != null)
+            {
+                sigV4Request.Headers.Add("x-amz-security-token", credentials.Token);
+            }
+
+            sigV4Request.Headers.Add("Host", this.endpoint.Host);
+            sigV4Request.Headers.Add("content-type", "application/x-protobuf");
+
+            foreach (var header in this.customHeaders)
+            {
+                sigV4Request.Headers.Add(header.Key, header.Value);
+            }
+
+            new AWS4Signer().Sign(sigV4Request, config, null, credentials);
+
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, this.endpoint);
+            foreach (var header in sigV4Request.Headers)
+            {
+                httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            httpRequest.Content = new ByteArrayContent(serializedData, 0, length);
+            httpRequest.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-protobuf");
+
+            var response = this.client.SendAsync(httpRequest).GetAwaiter().GetResult();
+            return response.IsSuccessStatusCode ? ExportResult.Success : ExportResult.Failure;
+        }
+        catch
+        {
+            return ExportResult.Failure;
+        }
+    }
+
+    private class EmptyAmazonWebServiceRequest : AmazonWebServiceRequest
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SigV4OtlpLogExporter` that signs OTLP HTTP requests with SigV4 for the CloudWatch Logs endpoint
- Add `OtlpExporterUtils.WriteLogsData()` for protobuf serialization of log records via reflection
- Update `Plugin.ConfigureLogsOptions()` to register both the console exporter and SigV4 OTLP exporter in Lambda environments using `SimpleLogRecordExportProcessor` (synchronous export)

## Key design decisions
- Uses `SimpleLogRecordExportProcessor` instead of batch to ensure logs flush before Lambda freezes
- Sets `AuthenticationServiceName = "logs"` on the SigV4 config (the root cause of previous 403s was defaulting to "xray")

## Test plan
- [x] Verified OTLP logs appear in CloudWatch `otlp-logs` stream with correct format
- [x] Verified console path (`exportPath: "console"`) still works
- [x] Verified all severity levels (DEBUG, INFO, WARN, ERROR) export correctly
- [X] E2E test 
   - Built plugin DLLs locally, packaged into Lambda layer zip
   - Deployed to DotNet_Test Lambda (us-east-1) via aws lambda publish-layer-version + update-function-configuration
   - Invoked function, verified logs appear in both:
   - Default CW stream: compact JSON with "exportPath":"console" (console path)
   - otlp-logs CW stream: CloudWatch OTLP-flattened format (SigV4 OTLP path)
   - Tested with both OTEL_LOGS_EXPORTER=none and OTEL_LOGS_EXPORTER=otlp
   - All severity levels (DEBUG, INFO, WARN, ERROR) confirmed in both streams

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

