### PR TITLE
fix: Update Lambda_Resource_Attributes

### DIFF
--- a/instrument.sh
+++ b/instrument.sh
@@ -192,7 +192,7 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
       export OTEL_SERVICE_NAME=$AWS_LAMBDA_FUNCTION_NAME;
     fi
     
-    export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,faas.instance=$AWS_LAMBDA_LOG_STREAM_NAME,aws.log.group.names=$AWS_LAMBDA_LOG_GROUP_NAME";
+    export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,cloud.platform=aws_lambda,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,faas.instance=$AWS_LAMBDA_LOG_STREAM_NAME,aws.log.group.names=$AWS_LAMBDA_LOG_GROUP_NAME";
 
     if [ -z "${OTEL_AWS_APPLICATION_SIGNALS_ENABLED}" ]; then
       export OTEL_AWS_APPLICATION_SIGNALS_ENABLED="true";


### PR DESCRIPTION
## Summary
- Add `cloud.platform=aws_lambda` to `LAMBDA_RESOURCE_ATTRIBUTES` in `instrument.sh`

## Test plan
- OTLP log validation (`log-schema-otlp.mustache`) expects `cloud.platform=aws_lambda`
- Console log validation (`log-schema-dotnet.mustache`) does not check this field — unaffected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

