### PR TITLE
ci(claude-review): use runtime API for author check

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,8 +16,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-author:
+    if: >-
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.title, '[skip-claude]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is_trusted: ${{ steps.check.outputs.is_trusted }}
+    steps:
+      - id: check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              const trusted = ['admin', 'maintain', 'write'].includes(data.permission);
+              core.info(`User ${author}: permission=${data.permission}, trusted=${trusted}`);
+              core.setOutput('is_trusted', trusted ? 'true' : 'false');
+            } catch (e) {
+              core.warning(`Failed to check permission for ${author}: ${e.message}`);
+              core.setOutput('is_trusted', 'false');
+            }
+
   claude-review:
-    if: ${{ !github.event.pull_request.draft }}
+    needs: check-author
+    if: needs.check-author.outputs.is_trusted == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
same as: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/767