### PR TITLE
Add e2e tests for Lambda .NET 10

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -244,21 +244,32 @@ jobs:
 
       - name: Build Lambda Sample App
         shell: bash
-        run: dotnet lambda package -pl ./src/SimpleLambdaFunction
+        run: |
+          dotnet lambda package --framework net8.0 -pl ./src/SimpleLambdaFunction -o ./function-net8.0.zip
+          dotnet lambda package --framework net10.0 -pl ./src/SimpleLambdaFunction -o ./function-net10.0.zip
         working-directory: sample-applications/lambda-test-apps/SimpleLambdaFunction
-      
+
       - name: Upload Sample App to S3
         shell: bash
         run: |
-          aws s3 cp ./src/SimpleLambdaFunction/bin/Release/net8.0/SimpleLambdaFunction.zip s3://adot-autoinstrumentation-dotnet-staging/function-${{ github.run_id }}.zip
+          # Runtime-specific artifacts consumed by the dotnet-lambda-test matrix.
+          aws s3 cp ./function-net8.0.zip s3://adot-autoinstrumentation-dotnet-staging/function-${{ github.run_id }}-dotnet8.zip
+          aws s3 cp ./function-net10.0.zip s3://adot-autoinstrumentation-dotnet-staging/function-${{ github.run_id }}-dotnet10.zip
+          # Legacy artifact kept for backward compatibility with the default (dotnet8) runtime.
+          aws s3 cp ./function-net8.0.zip s3://adot-autoinstrumentation-dotnet-staging/function-${{ github.run_id }}.zip
         working-directory: sample-applications/lambda-test-apps/SimpleLambdaFunction
-        
+
   dotnet-lambda-test:
     needs: [ build-lambda-staging-sample-app ]
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [ dotnet8, dotnet10 ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-lambda-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
+      runtime: ${{ matrix.runtime }}
       caller-workflow-name: 'main-build'
 
   # This validation is to ensure that all test workflows relevant to this repo are actually

--- a/sample-applications/lambda-test-apps/SimpleLambdaFunction/src/SimpleLambdaFunction/SimpleLambdaFunction.csproj
+++ b/sample-applications/lambda-test-apps/SimpleLambdaFunction/src/SimpleLambdaFunction/SimpleLambdaFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
Add e2e tests for the .NET 10 (dotnet10) Lambda runtime (previously only dotnet8 was tested).

Multi-targets the SimpleLambdaFunction sample app to net8.0;net10.0 and uploads a runtime-specific artifact for each so both runtimes can be exercised.

Depends on aws-observability/aws-application-signals-test-framework#659 (adds the runtime input + runtime-specific artifact download).

Note: not built locally (no .NET SDK on hand); relies on CI to validate the multi-target package build.