### PR TITLE
fix: build arch-specific Linux images so arm64 ships arm64 payload

### DIFF
--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -78,53 +78,6 @@ runs:
         docker buildx build --platform linux/amd64 -t ${{ inputs.image-name }}-amd64 -f ./Dockerfile.linux --load .
         docker buildx build --platform linux/arm64 -t ${{ inputs.image-name }}-arm64 -f ./Dockerfile.linux --load .
 
-    - name: Verify Linux image architecture payloads
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        set -euo pipefail
-        # Guards against the arch-agnostic COPY regression where an image is
-        # populated with the wrong architecture's payload. Re-run each platform
-        # build with a local filesystem output so the exact contents that are
-        # COPYed into the image can be inspected without starting a container
-        # (the distribution image is FROM scratch and has no shell). The layers
-        # are cached from the build step above, so this only exports the rootfs.
-        # For each platform we assert the shared store contains the expected
-        # architecture directory and that the native profiler is the matching
-        # ELF machine type (0x3e x86-64, 0xb7 aarch64).
-        verify() {
-          local platform="$1" store_arch="$2" native_dir="$3" want_machine="$4"
-          local outdir
-          outdir=$(mktemp -d)
-          docker buildx build --platform "$platform" -f ./Dockerfile.linux \
-            --output "type=local,dest=$outdir" .
-
-          if [ ! -d "$outdir/autoinstrumentation/store/$store_arch" ]; then
-            echo "ERROR: $platform image is missing autoinstrumentation/store/$store_arch"
-            echo "Present store dirs: $(ls "$outdir/autoinstrumentation/store" 2>/dev/null || echo none)"
-            exit 1
-          fi
-
-          local so="$outdir/autoinstrumentation/$native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
-          if [ ! -f "$so" ]; then
-            echo "ERROR: $platform image is missing native profiler $native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
-            exit 1
-          fi
-          # ELF header e_machine is a 2-byte little-endian field at offset 0x12.
-          local machine
-          machine=$(od -An -tx1 -j18 -N2 "$so" | tr -d ' \n')
-          if [ "$machine" != "$want_machine" ]; then
-            echo "ERROR: $platform profiler e_machine is 0x$machine, expected 0x$want_machine"
-            exit 1
-          fi
-          echo "OK: $platform has store/$store_arch and $native_dir profiler (e_machine 0x$machine)"
-          rm -rf "$outdir"
-        }
-
-        # ELF e_machine little-endian bytes: x86-64 => 3e00, AArch64 => b700
-        verify "linux/amd64" "x64" "linux-x64" "3e00"
-        verify "linux/arm64" "arm64" "linux-arm64" "b700"
-
     - name: Build Windows container
       if: runner.os == 'Windows'
       shell: powershell

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -84,46 +84,46 @@ runs:
       run: |
         set -euo pipefail
         # Guards against the arch-agnostic COPY regression where an image is
-        # populated with the wrong architecture's payload. For each image we assert
-        # the shared store contains the expected architecture directory and that the
-        # native profiler is the matching ELF machine type (0x3e x86-64, 0xb7 aarch64).
+        # populated with the wrong architecture's payload. Re-run each platform
+        # build with a local filesystem output so the exact contents that are
+        # COPYed into the image can be inspected without starting a container
+        # (the distribution image is FROM scratch and has no shell). The layers
+        # are cached from the build step above, so this only exports the rootfs.
+        # For each platform we assert the shared store contains the expected
+        # architecture directory and that the native profiler is the matching
+        # ELF machine type (0x3e x86-64, 0xb7 aarch64).
         verify() {
-          local image="$1" store_arch="$2" native_dir="$3" want_machine="$4"
-          local workdir cid
-          workdir=$(mktemp -d)
-          # The distribution image is FROM scratch (no shell/entrypoint), so it
-          # cannot be started. `docker create` with a dummy command still produces a
-          # container whose filesystem can be copied out with `docker cp`, which is
-          # independent of the image save/manifest format.
-          cid=$(docker create "$image" /nonexistent 2>/dev/null)
-          docker cp "$cid:/autoinstrumentation" "$workdir/autoinstrumentation"
-          docker rm "$cid" >/dev/null
+          local platform="$1" store_arch="$2" native_dir="$3" want_machine="$4"
+          local outdir
+          outdir=$(mktemp -d)
+          docker buildx build --platform "$platform" -f ./Dockerfile.linux \
+            --output "type=local,dest=$outdir" .
 
-          if [ ! -d "$workdir/autoinstrumentation/store/$store_arch" ]; then
-            echo "ERROR: $image is missing autoinstrumentation/store/$store_arch"
-            echo "Present store dirs: $(ls "$workdir/autoinstrumentation/store" 2>/dev/null || echo none)"
+          if [ ! -d "$outdir/autoinstrumentation/store/$store_arch" ]; then
+            echo "ERROR: $platform image is missing autoinstrumentation/store/$store_arch"
+            echo "Present store dirs: $(ls "$outdir/autoinstrumentation/store" 2>/dev/null || echo none)"
             exit 1
           fi
 
-          local so="$workdir/autoinstrumentation/$native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
+          local so="$outdir/autoinstrumentation/$native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
           if [ ! -f "$so" ]; then
-            echo "ERROR: $image is missing native profiler $native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
+            echo "ERROR: $platform image is missing native profiler $native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
             exit 1
           fi
           # ELF header e_machine is a 2-byte little-endian field at offset 0x12.
           local machine
           machine=$(od -An -tx1 -j18 -N2 "$so" | tr -d ' \n')
           if [ "$machine" != "$want_machine" ]; then
-            echo "ERROR: $image profiler e_machine is 0x$machine, expected 0x$want_machine"
+            echo "ERROR: $platform profiler e_machine is 0x$machine, expected 0x$want_machine"
             exit 1
           fi
-          echo "OK: $image has store/$store_arch and $native_dir profiler (e_machine 0x$machine)"
-          rm -rf "$workdir"
+          echo "OK: $platform has store/$store_arch and $native_dir profiler (e_machine 0x$machine)"
+          rm -rf "$outdir"
         }
 
         # ELF e_machine little-endian bytes: x86-64 => 3e00, AArch64 => b700
-        verify "${{ inputs.image-name }}-amd64" "x64" "linux-x64" "3e00"
-        verify "${{ inputs.image-name }}-arm64" "arm64" "linux-arm64" "b700"
+        verify "linux/amd64" "x64" "linux-x64" "3e00"
+        verify "linux/arm64" "arm64" "linux-arm64" "b700"
 
     - name: Build Windows container
       if: runner.os == 'Windows'

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -53,6 +53,8 @@ runs:
         # Stage each architecture's payload under OpenTelemetryDistribution/<arch>.
         # Dockerfile.linux copies OpenTelemetryDistribution/${TARGETARCH}, so a single
         # build context can produce correct amd64 and arm64 images.
+        # unzip does not create nested parent directories, so create them first.
+        mkdir -p ./OpenTelemetryDistribution/amd64 ./OpenTelemetryDistribution/arm64
         unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution/amd64
         unzip ./artifacts/linux/x64-musl/*.zip "linux-musl-x64/*" -d ./OpenTelemetryDistribution/amd64
         unzip ./artifacts/linux/arm64/*.zip -d ./OpenTelemetryDistribution/arm64

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -50,11 +50,13 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution
-        unzip ./artifacts/linux/x64-musl/*.zip "linux-musl-x64/*" -d ./OpenTelemetryDistribution
-        mkdir -p ./arm64
-        unzip ./artifacts/linux/arm64/*.zip -d ./arm64/OpenTelemetryDistribution
-        unzip ./artifacts/linux/arm64-musl/*.zip "linux-musl-arm64/*" -d ./arm64/OpenTelemetryDistribution
+        # Stage each architecture's payload under OpenTelemetryDistribution/<arch>.
+        # Dockerfile.linux copies OpenTelemetryDistribution/${TARGETARCH}, so a single
+        # build context can produce correct amd64 and arm64 images.
+        unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution/amd64
+        unzip ./artifacts/linux/x64-musl/*.zip "linux-musl-x64/*" -d ./OpenTelemetryDistribution/amd64
+        unzip ./artifacts/linux/arm64/*.zip -d ./OpenTelemetryDistribution/arm64
+        unzip ./artifacts/linux/arm64-musl/*.zip "linux-musl-arm64/*" -d ./OpenTelemetryDistribution/arm64
 
     - name: Unzip Windows Artifact
       if: runner.os == 'Windows'
@@ -73,6 +75,55 @@ runs:
         set -e
         docker buildx build --platform linux/amd64 -t ${{ inputs.image-name }}-amd64 -f ./Dockerfile.linux --load .
         docker buildx build --platform linux/arm64 -t ${{ inputs.image-name }}-arm64 -f ./Dockerfile.linux --load .
+
+    - name: Verify Linux image architecture payloads
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Guards against the arch-agnostic COPY regression where an image is
+        # populated with the wrong architecture's payload. For each image we assert
+        # the shared store contains the expected architecture directory and that the
+        # native profiler is the matching ELF machine type (0x3e x86-64, 0xb7 aarch64).
+        verify() {
+          local image="$1" store_arch="$2" native_dir="$3" want_machine="$4"
+          local workdir merged
+          workdir=$(mktemp -d)
+          merged="$workdir/merged"
+          mkdir -p "$merged"
+          # The distribution image is FROM scratch (no shell), so `docker create` +
+          # `docker export` cannot be used. Use `docker save` and flatten the layer
+          # blobs into a merged rootfs instead.
+          docker save "$image" | tar -C "$workdir" -xf -
+          while IFS= read -r layer; do
+            tar -C "$merged" -xf "$layer" 2>/dev/null || true
+          done < <(find "$workdir" -type f \( -name '*.tar' -o -path '*blobs/sha256/*' \))
+
+          if [ ! -d "$merged/autoinstrumentation/store/$store_arch" ]; then
+            echo "ERROR: $image is missing autoinstrumentation/store/$store_arch"
+            echo "Present store dirs: $(ls "$merged/autoinstrumentation/store" 2>/dev/null || echo none)"
+            exit 1
+          fi
+
+          local so="$merged/autoinstrumentation/$native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
+          if [ ! -f "$so" ]; then
+            echo "ERROR: $image is missing native profiler $native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
+            exit 1
+          fi
+          # ELF header e_machine is a 2-byte little-endian field at offset 0x12.
+          local machine
+          machine=$(od -An -tx1 -j18 -N2 "$so" | tr -d ' \n')
+          if [ "$machine" != "$want_machine" ]; then
+            echo "ERROR: $image profiler e_machine is 0x$machine, expected 0x$want_machine"
+            exit 1
+          fi
+          echo "OK: $image has store/$store_arch and $native_dir profiler (e_machine 0x$machine)"
+          rm -rf "$workdir"
+        }
+
+        # ELF e_machine little-endian bytes: x86-64 => 3e00, AArch64 => b700
+        verify "${{ inputs.image-name }}-amd64" "x64" "linux-x64" "3e00"
+        verify "${{ inputs.image-name }}-arm64" "arm64" "linux-arm64" "b700"
 
     - name: Build Windows container
       if: runner.os == 'Windows'

--- a/.github/actions/build-and-scan-image/action.yml
+++ b/.github/actions/build-and-scan-image/action.yml
@@ -89,25 +89,23 @@ runs:
         # native profiler is the matching ELF machine type (0x3e x86-64, 0xb7 aarch64).
         verify() {
           local image="$1" store_arch="$2" native_dir="$3" want_machine="$4"
-          local workdir merged
+          local workdir cid
           workdir=$(mktemp -d)
-          merged="$workdir/merged"
-          mkdir -p "$merged"
-          # The distribution image is FROM scratch (no shell), so `docker create` +
-          # `docker export` cannot be used. Use `docker save` and flatten the layer
-          # blobs into a merged rootfs instead.
-          docker save "$image" | tar -C "$workdir" -xf -
-          while IFS= read -r layer; do
-            tar -C "$merged" -xf "$layer" 2>/dev/null || true
-          done < <(find "$workdir" -type f \( -name '*.tar' -o -path '*blobs/sha256/*' \))
+          # The distribution image is FROM scratch (no shell/entrypoint), so it
+          # cannot be started. `docker create` with a dummy command still produces a
+          # container whose filesystem can be copied out with `docker cp`, which is
+          # independent of the image save/manifest format.
+          cid=$(docker create "$image" /nonexistent 2>/dev/null)
+          docker cp "$cid:/autoinstrumentation" "$workdir/autoinstrumentation"
+          docker rm "$cid" >/dev/null
 
-          if [ ! -d "$merged/autoinstrumentation/store/$store_arch" ]; then
+          if [ ! -d "$workdir/autoinstrumentation/store/$store_arch" ]; then
             echo "ERROR: $image is missing autoinstrumentation/store/$store_arch"
-            echo "Present store dirs: $(ls "$merged/autoinstrumentation/store" 2>/dev/null || echo none)"
+            echo "Present store dirs: $(ls "$workdir/autoinstrumentation/store" 2>/dev/null || echo none)"
             exit 1
           fi
 
-          local so="$merged/autoinstrumentation/$native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
+          local so="$workdir/autoinstrumentation/$native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
           if [ ! -f "$so" ]; then
             echo "ERROR: $image is missing native profiler $native_dir/OpenTelemetry.AutoInstrumentation.Native.so"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For any change that affects end users of this package, please add an entry under
 If your change does not need a CHANGELOG entry, add the "skip changelog" label to your PR.
 
 ## Unreleased
+- Fix Linux arm64 image being built with the x64 payload, which caused the shared
+  store and native profiler to not match the image architecture and made .NET
+  applications fail to start on arm64. Images are now built per architecture.
+  ([#424](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/424))
 
 ## v1.13.0 - 2026-06-06
 - Update OpenTelemetry dependencies - Core: 1.15.3, Instrumentation: 1.15.0

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -37,8 +37,17 @@ RUN if [ $TARGETARCH = "amd64" ]; then export ARCH="x86_64" ; \
 # Stage 2: Build the distribution image by copying the THIRD-PARTY-LICENSES, the custom built cp command from stage 1, and OpenTelemetryDistribution to their respective destinations
 FROM scratch
 
+# TARGETARCH is automatically defined by Docker when using --platform flag and is
+# used to select the matching architecture-specific distribution below. It must be
+# re-declared here because ARGs do not carry across build stages.
+ARG TARGETARCH
+
 # Required to copy attribute files to distributed docker images
 ADD THIRD-PARTY-LICENSES ./THIRD-PARTY-LICENSES
 
 COPY --from=builder /usr/src/cp-utility/bin/cp-utility /bin/cp
-COPY OpenTelemetryDistribution /autoinstrumentation
+# Copy the distribution matching the target architecture. The build context stages
+# the per-architecture payloads under OpenTelemetryDistribution/<arch> so that the
+# arm64 image receives arm64 assets (store/arm64 and the aarch64 native profiler)
+# rather than the x64 payload.
+COPY OpenTelemetryDistribution/${TARGETARCH} /autoinstrumentation


### PR DESCRIPTION
## Summary

The Linux auto-instrumentation image for `arm64` is being published with the
**x64 payload**. Both the `linux/amd64` and `linux/arm64` images are built from
the same build context, and `Dockerfile.linux` copied a single, architecture-
agnostic `OpenTelemetryDistribution` directory:

```dockerfile
COPY OpenTelemetryDistribution /autoinstrumentation
```

`docker buildx build --platform linux/arm64` sets the platform for the base
image and the (arch-agnostic) `scratch`/builder stages, but it does **not**
redirect this hardcoded `COPY`. As a result the arm64 image ends up with:

- `autoinstrumentation/store/x64` (no `store/arm64`), and
- the x86-64 `OpenTelemetry.AutoInstrumentation.Native.so` profiler.

On arm64 nodes `instrument.sh` correctly resolves `aarch64` → `arm64` and points
`DOTNET_SHARED_STORE` at a `store/arm64` directory that does not exist, so the
.NET `AdditionalDeps` manifest cannot resolve its assemblies (e.g.
`Microsoft.Extensions.Logging.Configuration`) and instrumented applications
**fail at startup**.

## Changes

- **`Dockerfile.linux`** — re-declare `ARG TARGETARCH` in the final stage and
  copy `OpenTelemetryDistribution/${TARGETARCH}`, so each image gets the payload
  matching its architecture.
- **`.github/actions/build-and-scan-image/action.yml`** — stage each Linux
  architecture's payload under `OpenTelemetryDistribution/<arch>`
  (`amd64` / `arm64`) so the arch-specific `COPY` resolves correctly.

## Test plan

Validated locally by staging real per-arch payloads and building both images
with the updated `Dockerfile.linux`:

- [x] `amd64` image contains `store/x64` and a `linux-x64` profiler with ELF
      `e_machine == 0x3e` (x86-64).
- [x] `arm64` image contains `store/arm64` and a `linux-arm64` profiler with ELF
      `e_machine == 0xb7` (aarch64).
- [x] Negative control: a build that stages the x64 payload as arm64 produces
      `store/x64`, confirming the mismatch would previously have shipped.

## Follow-up

CI currently has no arm64 runtime coverage, which is why this regression was not
caught. A dedicated arm64 end-to-end test will be added separately to guard
against this class of packaging issue going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)