### PR TITLE
fix: stage Linux artifact under amd64 subdir

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Unzip Linux Artifact
         if: runner.os == 'Linux'
         run: |
-          unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution
+          mkdir -p ./OpenTelemetryDistribution/amd64
+          unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution/amd64
 
       - name: Set up Docker Buildx
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
The main build was failing at the upload-main-build-image job because #424 changed Dockerfile.linux to copy an architecture-specific path `(COPY OpenTelemetryDistribution/${TARGETARCH}) `but didn't update this workflow, which still unzipped the artifact into a non-arch path (OpenTelemetryDistribution/). As a result the amd64 image build couldn't find OpenTelemetryDistribution/amd64 and failed with "/OpenTelemetryDistribution/amd64": not found.

This PR fixes that by staging the Linux artifact into the amd64/ subdirectory so it matches the Dockerfile's ${TARGETARCH} layout.

## Changes
Stage the Linux artifact under the amd64 subdirectory to match the Dockerfile's ${TARGETARCH} layout (unzip doesn't create nested parents, so mkdir -p first):

`mkdir -p ./OpenTelemetryDistribution/amd64`
`unzip ./artifacts/linux/x64/*.zip -d ./OpenTelemetryDistribution/amd64`
One-line change to .github/workflows/application-signals-e2e-test.yml.

## Testing Done
 Reproduced the failure locally against the real Dockerfile.linux: staging without the amd64 subdir produces the exact "/OpenTelemetryDistribution/amd64": not found error.
 Verified the fix locally: staging into OpenTelemetryDistribution/amd64 lets the COPY resolve and the image build complete.
 Ran the full [main-build.yml](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/29033652047) on a temp branch with this fix applied, exercising the actual upload-main-build-image job end-to-end on native amd64 CI — the Docker build step passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

