### PR TITLE
[Feat]: Add function-level capture engine for .NET Dynamic Instrumentation

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -105,7 +105,7 @@ jobs:
           set -e
           docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
           docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
-            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
+            /bin/sh -c 'git config --global --add safe.directory /project && ./build.sh && dotnet test'
 
       - name: Upload Artifact on MUSL X64 Linux
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
@@ -156,7 +156,7 @@ jobs:
           set -e
           docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
           docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
-            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
+            /bin/sh -c 'git config --global --add safe.directory /project && ./build.sh && dotnet test'
 
       - name: Upload Artifact on MUSL arm64 Linux
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -218,7 +218,7 @@ jobs:
           set -e
           docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
           docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
-            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
+            /bin/sh -c 'git config --global --add safe.directory /project && ./build.sh && dotnet test'
 
       - name: Upload Artifact on MUSL X64 Linux
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
@@ -239,7 +239,7 @@ jobs:
           set -e
           docker build -t mybuildimage -f "./docker/alpine.dockerfile" ./docker
           docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
-            /bin/sh -c 'git config --global --add safe.directory /project && dotnet test && ./build.sh'
+            /bin/sh -c 'git config --global --add safe.directory /project && ./build.sh && dotnet test'
 
       - name: Upload Artifact on MUSL arm64 Linux
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/docs/dynamic-instrumentation.md
+++ b/docs/dynamic-instrumentation.md
@@ -1,0 +1,206 @@
+# Dynamic Instrumentation (.NET) — Function-Level Capabilities & Limitations
+
+This document describes what the .NET Dynamic Instrumentation (DI) function-level capture engine
+supports today, and — just as important — where its edges are. It is grounded in the current
+implementation; each limitation names the code that enforces it.
+
+Function-level DI lets an operator remotely configure a **probe** (capture at method entry/exit)
+on a running .NET service with no redeploy. Configs are polled from the backend and woven into the
+running process by the OpenTelemetry .NET AutoInstrumentation native CLR profiler via ReJIT.
+
+> **Line-level DI is out of scope here.** Capturing at a specific source line inside a method body
+> is a separate, later effort. Function-level is entry/exit only.
+
+---
+
+## What is captured
+
+At entry and exit of an instrumented method, a snapshot may include:
+
+- **Arguments** — subject to the `CaptureArguments` filter (see below).
+- **Return value** — when `CaptureReturn` is enabled.
+- **Exception** — type, message (truncated to `MaxStringLength`), and a filtered/capped stack trace.
+- **Trace context** — `TraceId`/`SpanId` when an `Activity` is active.
+- **Thread info** and **method duration**.
+
+Values are serialized depth- and width-limited by `ValueSerializer` (see *Capture limits* below).
+
+### Argument capture is positional (first-N), not select-by-name
+
+`CaptureArguments` controls which arguments are captured (`DiIntegrationHelper.OnMethodBegin`):
+
+- **Empty filter** → capture **every** argument, labeled positionally `arg0`, `arg1`, ….
+- **Non-empty filter** (e.g. `["orderId", "quantity"]`) → capture the **first N arguments** where
+  `N = filter length`, applying the filter entries as **labels** in order. Bounded by the actual
+  argument count, so a filter longer than the argument list just captures what exists.
+
+**Limitation — you cannot yet cherry-pick arbitrary parameters by name.** The filter is *positional*:
+its entries rename the leading arguments; they are **not** matched against the method's real parameter
+names. So on a method `Foo(a, b, c, d, e)` you can capture the first 2 (`a`, `b`) but you **cannot**
+capture only `c` and `e`, or reorder. The woven callback receives arguments as a positional `object?[]`
+with no parameter-name metadata, so name-based selection needs reflection over the target method — a
+tracked follow-up (see the open review note on preferring real argument names). Until then:
+
+- To capture a specific subset, it must be a **contiguous prefix** of the parameter list.
+- The names you supply are cosmetic labels applied left-to-right, not a lookup key.
+
+> **Consequence for wide methods:** even setting aside the parameter cap below, "capture only these 4 of
+> 20" is only expressible today if those 4 are the first 4 parameters.
+
+---
+
+## Supported targets
+
+| Target kind | Supported? | Enforced by |
+|---|---|---|
+| Instance methods | ✅ | `ProfilerTranslator` |
+| Static methods | ✅ | `ProfilerTranslator` |
+| **Async methods** (`Task`/`Task<T>`/`ValueTask`/`ValueTask<T>`) | ✅ (see below) | `DiIntegrationHelper.OnAsyncMethodEnd` |
+| Overloaded methods (by parameter count) | ✅ with a caveat (see *Arity*) | `InstrumentationRegistry.IndexArities` |
+| Constructors (`.ctor`) / static constructors (`.cctor`) | ❌ | `ProfilerTranslator.IsUnsupportedTarget` |
+| Methods with `ref`/`out`/`in` by-ref parameters | ❌ (skipped by profiler) | native profiler `method_rewriter.cpp` |
+| Static methods on a value type (`struct`) | ❌ (skipped by profiler) | native profiler `method_rewriter.cpp` |
+| Generic **struct** instance methods | ❌ (skipped by profiler) | native profiler `method_rewriter.cpp` |
+| Methods with **more than 9 parameters** | ❌ (see *Arity cap*) | `ProfilerTranslator.MaxSupportedParams` |
+
+---
+
+## Async methods
+
+**Supported without a profiler fork.** For an `async` method the woven method returns an
+*incomplete* `Task`/`ValueTask`. Serializing that task synchronously would capture an unfinished
+result and could block or deadlock the caller (e.g. touching `Task.Result`).
+
+The profiler's CallTarget mechanism already solves this: it **awaits** the returned task and then
+calls a separate `OnAsyncMethodEnd` callback with the **completed, unwrapped result**
+(`T` for `Task<T>`/`ValueTask<T>`; a null object for non-generic `Task`/`ValueTask`), or the fault
+if the task threw. This is the profiler's built-in continuation
+(`IntegrationMapper.CreateAsyncEndMethodDelegate` / `TaskContinuationGenerator`).
+
+Accordingly, our capture engine:
+
+1. **Defers on the synchronous end** for any awaitable return type — `DiIntegrationHelper.OnMethodEnd`
+   returns early (capturing nothing, leaving the paired entry intact) when the return is
+   `Task`/`Task<T>`/`ValueTask`/`ValueTask<T>`, matching the profiler's own
+   `NoCodeIntegrationHelper.OnMethodEnd`.
+2. **Captures on `OnAsyncMethodEnd`** — `DiIntegrationHelper.OnAsyncMethodEnd` records the completed,
+   unwrapped return value (and any fault) exactly once.
+
+**Limitation:** capture fires when the returned task **completes**, not at the C# `await` points
+inside the method body. Locals across `await` boundaries are a line-level concern and are not
+captured by function-level DI.
+
+---
+
+## Arity (parameter-count) cap
+
+**Hard limit: 9 parameters. Not configurable.**
+
+The engine ships ten fixed CallTarget integration types, `DiIntegration0` … `DiIntegration9`, one per
+parameter count (`ProfilerTranslator.MaxSupportedParams = 9`). A method (or overload) with **more than
+9 parameters is not instrumented**.
+
+Why fixed, and why not configurable:
+- Each `DiIntegrationN` is a distinct generic type the profiler binds by signature-array length. The
+  set is compiled into the assembly; there is no runtime knob that would make the profiler accept an
+  11th generic argument.
+- Raising the cap would require either more generated integration types or switching to the profiler's
+  `object[]` slow-path weave — a larger change deferred out of function-level v1.
+
+**Behavior at the boundary (this is the reportable-vs-partial distinction):**
+
+- If a method has **overloads at both supported and unsupported arities** (e.g. a 4-param and a
+  12-param overload), the supported overloads are woven and the over-cap overloads are **silently
+  skipped**. The apply result is `Applied` — a partial success, not an error.
+- If **every** overload exceeds the cap, apply returns `NoSupportedArity` — a **permanent
+  instrumentation failure** reported (PR3) as an `ERROR` status with cause `RUNTIME_ERROR`. The
+  operator-facing message names the ">9 parameters" reason; the coarse backend enum has no
+  arity-specific member.
+
+> **"Capture only 4 of a method's 20 parameters" — can I?** No, not today, for two independent reasons:
+> (1) a 20-parameter method exceeds the arity cap, so it is never woven at all (`NoSupportedArity`); and
+> (2) even under the cap, `CaptureArguments` is positional (first-N), so a subset must be a leading prefix
+> — see *Argument capture is positional* above. For a method with ≤9 parameters, capturing the first 4
+> is fully supported.
+
+---
+
+## Overload disambiguation (same-arity collision)
+
+The woven callback receives `(instance, args)` but **not** the method name or token. Co-located
+methods are disambiguated by **parameter count** (`args.Length`), indexed at apply time by
+`InstrumentationRegistry.IndexArities`.
+
+**Limitation:** two instrumented methods on the **same type with the same parameter count** cannot be
+told apart at capture time. This is a documented residual — a capture may be attributed to either
+config sharing that `(type, arity)` bucket. (A future enhancement is an optional `Signature` field so
+the profiler binds by exact parameter types.)
+
+---
+
+## Removal / uninstrumenting
+
+**Removal is logical, not physical.** The native profiler exposes **no revert/remove export** (there
+is no `RequestRevert`; the P/Invoke surface is `AddInstrumentations` only — see `NativeMethods.cs`).
+A method whose IL was rewritten by ReJIT therefore **stays woven** for the life of the process.
+
+When the backend removes a config, the SDK drops it from the `InstrumentationRegistry`
+(`DynamicInstrumentationManager.OnConfigurationsChanged` → `RemoveStale`). On the next invocation the
+still-woven `DiIntegration` callback finds no matching config (`registry.TryHit`/`Get` return
+`false`/`null`), so `OnMethodBegin` short-circuits and **no snapshot is produced**. The residual cost
+is the cheap woven prologue/epilogue that immediately returns.
+
+**Implication:** removing a probe stops all captures for it immediately, but does not restore the
+method's original (un-woven) IL until the process restarts.
+
+---
+
+## Capture limits (partial captures are *not* instrumentation errors)
+
+Individual values are serialized within limits (`CaptureConfiguration`): `MaxStringLength`,
+`MaxCollectionWidth`, `MaxCollectionDepth`, `MaxObjectDepth`, `MaxFieldsPerObject`, `MaxStackFrames`,
+and (breakpoints) `MaxHits`.
+
+When a value can't be fully serialized, the snapshot carries a per-value `NotCapturedReason`
+(`Depth`, `FieldCount`, `CollectionSize`, `Timeout`, `AlreadyCaptured`). **This is a capture-level
+partial, reported inside the snapshot — it is never an `ERROR` status on the configuration.** Only a
+weave failure (see below) is an instrumentation `ERROR`.
+
+- **Collections** are only walked when their size is known in O(1) (arrays, `ICollection<T>`,
+  `IReadOnlyCollection<T>`, etc.); a countless `IEnumerable` is serialized as an object, not walked,
+  so a lazy/infinite sequence is never enumerated on the user thread (`ValueSerializer`).
+
+---
+
+## Error-status taxonomy (instrumentation-failed vs capture-failed)
+
+Two distinct failure channels — do not conflate them:
+
+| Kind | Meaning | Where reported | Source |
+|---|---|---|---|
+| **Instrumentation failed** | The target could not be woven at all | `ERROR` status on the configuration | `InstrumentationApplyResult` + `MapErrorCause` |
+| **Capture failed (partial)** | The method was woven and ran, but a value couldn't be fully serialized | `NotCapturedReason` inside the snapshot | `Capture.NotCapturedReason` |
+
+Instrumentation-failed causes and their backend `ErrorCause` mapping
+(`InstrumentationApplyResultExtensions.MapErrorCause`):
+
+| Apply result | Reportable? | Backend `ErrorCause` | Meaning |
+|---|---|---|---|
+| `Applied` | no | — | Woven (possibly partial across arities). |
+| `Skipped` | no | — | Intentionally not applied (unsupported target). |
+| `TypeNotLoaded` | no (retried) | — | Target assembly not loaded yet; retried on a later poll, never reported (would spam every poll). |
+| `MethodNotFound` | yes | `METHOD_NOT_FOUND` | Type resolved but has no method of that name. |
+| `NoSupportedArity` | yes | `RUNTIME_ERROR` | Every overload exceeds the 9-parameter cap. |
+| `RuntimeError` | yes | `RUNTIME_ERROR` | The native `AddInstrumentations` call threw. |
+
+> **Status emission** (`StatusReporter.ReportError`) is wired in a later PR (PR3). The taxonomy and
+> mapping above are in place now; the manager calls the hook at the point of failure
+> (see the `TODO(PR3)` markers in `DynamicInstrumentationManager.OnConfigurationsChanged`).
+
+---
+
+## Runtime / platform scope
+
+- **.NET 8, 9, 10** (`net8.0;net9.0;net10.0`). .NET Framework (net462) is not supported.
+- Requires the AWS-distributed OpenTelemetry .NET AutoInstrumentation native profiler; DI is loaded
+  as a plugin (`OTEL_DOTNET_AUTO_PLUGINS`).

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj
@@ -33,4 +33,15 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+  <!-- PR2: the native profiler resolves CallTargetState by type identity, so our integration
+       classes must return its REAL type, not a look-alike. Reference (not copy) the
+       distribution's assembly. TODO(ship): decide how this is sourced for GA (built
+       distribution path vs package) — see DI-LINE-LEVEL-ARCHITECTURE DECISION on dll sourcing. -->
+  <ItemGroup>
+    <Reference Include="OpenTelemetry.AutoInstrumentation">
+      <HintPath>..\..\OpenTelemetryDistribution\net\OpenTelemetry.AutoInstrumentation.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj
@@ -37,11 +37,23 @@
        classes must return its REAL type, not a look-alike. Reference (not copy) the
        distribution's assembly. TODO(ship): decide how this is sourced for GA (built
        distribution path vs package) — see DI-LINE-LEVEL-ARCHITECTURE DECISION on dll sourcing. -->
+  <PropertyGroup>
+    <OTelAutoInstrumentationDll>$(MSBuildThisFileDirectory)..\..\OpenTelemetryDistribution\net\OpenTelemetry.AutoInstrumentation.dll</OTelAutoInstrumentationDll>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTelemetry.AutoInstrumentation">
-      <HintPath>..\..\OpenTelemetryDistribution\net\OpenTelemetry.AutoInstrumentation.dll</HintPath>
+      <HintPath>$(OTelAutoInstrumentationDll)</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+
+  <!-- The reference above is a build artifact that build.sh downloads/unpacks into
+       OpenTelemetryDistribution/. A plain `dotnet build`/`dotnet test` on a fresh clone (or a CI job
+       that tests before running build.sh) won't have it, which otherwise fails with dozens of opaque
+       CS0234/CS0246 errors. Fail fast with one actionable message instead. -->
+  <Target Name="EnsureOTelAutoInstrumentationDll" BeforeTargets="ResolveAssemblyReferences">
+    <Error Condition="!Exists('$(OTelAutoInstrumentationDll)')"
+           Text="OpenTelemetry.AutoInstrumentation.dll not found at $(OTelAutoInstrumentationDll). Run ./build.sh (macOS/Linux) or build.cmd (Windows) first to download and unpack the OpenTelemetry distribution before building or testing this project." />
+  </Target>
 
 </Project>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj
@@ -33,10 +33,8 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
-  <!-- PR2: the native profiler resolves CallTargetState by type identity, so our integration
-       classes must return its REAL type, not a look-alike. Reference (not copy) the
-       distribution's assembly. TODO(ship): decide how this is sourced for GA (built
-       distribution path vs package) — see DI-LINE-LEVEL-ARCHITECTURE DECISION on dll sourcing. -->
+  <!-- The native profiler resolves CallTargetState by type identity, so our integration classes must
+       return the profiler's real type. Reference (do not copy) the distribution's assembly. -->
   <PropertyGroup>
     <OTelAutoInstrumentationDll>$(MSBuildThisFileDirectory)..\..\OpenTelemetryDistribution\net\OpenTelemetry.AutoInstrumentation.dll</OTelAutoInstrumentationDll>
   </PropertyGroup>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/CaptureState.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/CaptureState.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+/// <summary>
+/// Stashed in the profiler's CallTargetState between OnMethodBegin and OnMethodEnd. Carries the
+/// instrumentation key plus a per-call id so each (possibly recursive) invocation pairs with its own
+/// entry in <see cref="DIDataStore"/>.
+/// </summary>
+/// <param name="InstrumentationKey">The instrumentation key of the woven config.</param>
+/// <param name="CallId">Unique id for this invocation, issued by <see cref="DIDataStore.RecordEntry"/>.</param>
+internal sealed record CaptureState(string InstrumentationKey, long CallId);

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/CaptureType.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/CaptureType.cs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+internal enum CaptureType
+{
+    METHOD,
+    LINE,
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/CapturedValue.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/CapturedValue.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+internal sealed class CapturedValue
+{
+    public string Type { get; init; } = string.Empty;
+
+    public string? Value { get; init; }
+
+    public bool Truncated { get; init; }
+
+    /// <summary>Gets why this value was not fully captured; <see cref="NotCapturedReason.None"/> if it was.</summary>
+    public NotCapturedReason NotCapturedReason { get; init; } = NotCapturedReason.None;
+
+    public Dictionary<string, CapturedValue>? Fields { get; init; }
+
+    public CapturedValue[]? Elements { get; init; }
+
+    public int? OriginalSize { get; init; }
+
+    /// <summary>
+    /// Gets the internal-frame-filtered, capped stack frames for a captured exception, or null
+    /// when this value is not an exception. Preferred over storing the raw StackTrace string.
+    /// </summary>
+    public StackFrameInfo[]? StackFrames { get; init; }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/DIDataStore.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/DIDataStore.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Threading;
 
 namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
 
@@ -11,7 +12,8 @@ namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
 internal static class DIDataStore
 {
     private static readonly ConcurrentQueue<PendingCapture> Queue = new();
-    private static readonly AsyncLocal<Dictionary<string, PendingEntryData>> PendingEntries = new();
+    private static readonly AsyncLocal<Dictionary<long, PendingEntryData>> PendingEntries = new();
+    private static long callIdSeed;
 
     public static int Count => Queue.Count;
 
@@ -37,26 +39,27 @@ internal static class DIDataStore
         PendingEntries.Value?.Clear();
     }
 
-    /// <summary>Stores entry data (keyed by instrumentation key) when OnMethodBegin fires.</summary>
-    public static void RecordEntry(string instrumentationKey, PendingEntryData entry)
+    /// <summary>
+    /// Records entry data when OnMethodBegin fires and returns a unique call id to pair with
+    /// OnMethodEnd. Keyed per-call (not per instrumentation key) so recursive/reentrant calls on the
+    /// same method each keep their own entry — the innermost End no longer overwrites the outer one.
+    /// </summary>
+    public static long RecordEntry(PendingEntryData entry)
     {
-        PendingEntries.Value ??= new Dictionary<string, PendingEntryData>();
-        PendingEntries.Value[instrumentationKey] = entry;
+        var callId = Interlocked.Increment(ref callIdSeed);
+        PendingEntries.Value ??= new Dictionary<long, PendingEntryData>();
+        PendingEntries.Value[callId] = entry;
+        return callId;
     }
 
-    /// <summary>Retrieves and removes entry data when OnMethodEnd fires, returning null if there is no matching entry.</summary>
-    public static PendingEntryData? RetrieveEntry(string instrumentationKey)
+    /// <summary>Retrieves and removes the entry for a call id when OnMethodEnd fires; null if absent.</summary>
+    public static PendingEntryData? RetrieveEntry(long callId)
     {
         if (PendingEntries.Value == null)
         {
             return null;
         }
 
-        if (PendingEntries.Value.Remove(instrumentationKey, out var entry))
-        {
-            return entry;
-        }
-
-        return null;
+        return PendingEntries.Value.Remove(callId, out var entry) ? entry : null;
     }
 }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/DIDataStore.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/DIDataStore.cs
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+/// <summary>Thread-safe capture queue plus AsyncLocal entry/exit pairing that DiIntegration callbacks enqueue to and DISnapshotCollector drains.</summary>
+// AsyncLocal is correct for sync methods and the synchronous preamble of async methods (before the first await), which is where the OnMethodBegin/OnMethodEnd callbacks run.
+internal static class DIDataStore
+{
+    private static readonly ConcurrentQueue<PendingCapture> Queue = new();
+    private static readonly AsyncLocal<Dictionary<string, PendingEntryData>> PendingEntries = new();
+
+    public static int Count => Queue.Count;
+
+    public static void Enqueue(PendingCapture capture) => Queue.Enqueue(capture);
+
+    public static List<PendingCapture> Drain()
+    {
+        var list = new List<PendingCapture>();
+        while (Queue.TryDequeue(out var item))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    public static void Clear()
+    {
+        while (Queue.TryDequeue(out _))
+        {
+        }
+
+        PendingEntries.Value?.Clear();
+    }
+
+    /// <summary>Stores entry data (keyed by instrumentation key) when OnMethodBegin fires.</summary>
+    public static void RecordEntry(string instrumentationKey, PendingEntryData entry)
+    {
+        PendingEntries.Value ??= new Dictionary<string, PendingEntryData>();
+        PendingEntries.Value[instrumentationKey] = entry;
+    }
+
+    /// <summary>Retrieves and removes entry data when OnMethodEnd fires, returning null if there is no matching entry.</summary>
+    public static PendingEntryData? RetrieveEntry(string instrumentationKey)
+    {
+        if (PendingEntries.Value == null)
+        {
+            return null;
+        }
+
+        if (PendingEntries.Value.Remove(instrumentationKey, out var entry))
+        {
+            return entry;
+        }
+
+        return null;
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/DIDataStore.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/DIDataStore.cs
@@ -12,7 +12,12 @@ namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
 internal static class DIDataStore
 {
     private static readonly ConcurrentQueue<PendingCapture> Queue = new();
-    private static readonly AsyncLocal<Dictionary<long, PendingEntryData>> PendingEntries = new();
+
+    // ConcurrentDictionary, not Dictionary: AsyncLocal's copy-on-write isolates only the slot (the
+    // reference), and only when .Value is assigned. When a probed method fans out to probed children
+    // (Parallel.ForEach/Task.Run), the same dictionary flows to every child, whose RecordEntry/RetrieveEntry
+    // then mutate it concurrently. Call ids are globally unique, so a concurrent-safe map is fully correct.
+    private static readonly AsyncLocal<ConcurrentDictionary<long, PendingEntryData>> PendingEntries = new();
     private static long callIdSeed;
 
     public static int Count => Queue.Count;
@@ -47,7 +52,7 @@ internal static class DIDataStore
     public static long RecordEntry(PendingEntryData entry)
     {
         var callId = Interlocked.Increment(ref callIdSeed);
-        PendingEntries.Value ??= new Dictionary<long, PendingEntryData>();
+        PendingEntries.Value ??= new ConcurrentDictionary<long, PendingEntryData>();
         PendingEntries.Value[callId] = entry;
         return callId;
     }
@@ -60,6 +65,6 @@ internal static class DIDataStore
             return null;
         }
 
-        return PendingEntries.Value.Remove(callId, out var entry) ? entry : null;
+        return PendingEntries.Value.TryRemove(callId, out var entry) ? entry : null;
     }
 }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/NotCapturedReason.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/NotCapturedReason.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+/// <summary>
+/// Why a value was not fully captured. Emitted alongside a truncated/partial value so consumers can
+/// distinguish limit reasons. Names mirror the Java/Python/JS SDKs (DEPTH/FIELD_COUNT/COLLECTION_SIZE/
+/// TIMEOUT/ALREADY_CAPTURED).
+/// </summary>
+internal enum NotCapturedReason
+{
+    /// <summary>The value was fully captured; nothing was dropped.</summary>
+    None,
+
+    /// <summary>Object- or collection-nesting depth limit was reached.</summary>
+    Depth,
+
+    /// <summary>The per-object field count limit was reached.</summary>
+    FieldCount,
+
+    /// <summary>The per-collection element (width) limit was reached.</summary>
+    CollectionSize,
+
+    /// <summary>The serialization time budget was exceeded.</summary>
+    Timeout,
+
+    /// <summary>The value was already captured earlier in this graph (reference cycle).</summary>
+    AlreadyCaptured,
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/PendingCapture.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/PendingCapture.cs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+internal sealed class PendingCapture
+{
+    public CaptureType Type { get; init; }
+
+    public string InstrumentationKey { get; init; } = string.Empty;
+
+    public string LocationHash { get; init; } = string.Empty;
+
+    public long TimestampMs { get; init; }
+
+    public long DurationMs { get; init; }
+
+    public string? TraceId { get; init; }
+
+    public string? SpanId { get; init; }
+
+    public int ThreadId { get; init; }
+
+    public string? ThreadName { get; init; }
+
+    public Dictionary<string, CapturedValue>? Arguments { get; init; }
+
+    public CapturedValue? ReturnValue { get; init; }
+
+    public CapturedValue? Exception { get; init; }
+
+    public Dictionary<string, CapturedValue>? Locals { get; init; }
+
+    public int LineNumber { get; init; }
+
+    public StackFrameInfo[]? StackTrace { get; init; }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/PendingEntryData.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/PendingEntryData.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+/// <summary>
+/// Data captured at method entry, held until method exit.
+/// </summary>
+internal sealed class PendingEntryData
+{
+    public string InstrumentationKey { get; init; } = string.Empty;
+
+    public string LocationHash { get; init; } = string.Empty;
+
+    public long StartTimestamp { get; init; }
+
+    public Dictionary<string, CapturedValue>? Arguments { get; init; }
+
+    public string? TraceId { get; init; }
+
+    public string? SpanId { get; init; }
+
+    public int ThreadId { get; init; }
+
+    public string? ThreadName { get; init; }
+
+    public StackFrameInfo[]? StackTrace { get; init; }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/StackFrameInfo.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/StackFrameInfo.cs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+internal sealed record StackFrameInfo(string? FileName, string? MethodName, int LineNumber);

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/ValueSerializer.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/ValueSerializer.cs
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections;
+using System.Reflection;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+internal static class ValueSerializer
+{
+    private const string DepthLimitReached = "<depth limit reached>";
+    private const string AlreadyCaptured = "<already captured>";
+
+    public static CapturedValue Serialize(object? value, CaptureConfiguration limits, int depth = 0)
+        => Serialize(value, limits, objectDepth: depth, collectionDepth: depth, visited: new HashSet<object>(ReferenceEqualityComparer.Instance));
+
+    // Object nesting and collection nesting are bounded independently: a chain of nested
+    // objects is limited by MaxObjectDepth, a chain of nested collections/dictionaries by
+    // MaxCollectionDepth. Each container checks its own budget before recursing, so cyclic
+    // object graphs and self-referencing collections both terminate even without identity tracking.
+    // In ADDITION, `visited` tracks reference identity so a value revisited within its own ancestry
+    // is reported as AlreadyCaptured before the depth cap is hit (matches Java/JS circular detection).
+    private static CapturedValue Serialize(object? value, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
+    {
+        if (value == null)
+        {
+            return new CapturedValue { Type = "null", Value = "null" };
+        }
+
+        var type = value.GetType();
+        var typeName = type.FullName ?? type.Name;
+
+        if (IsPrimitive(type))
+        {
+            return SerializePrimitive(value, typeName);
+        }
+
+        if (type == typeof(string))
+        {
+            return SerializeString((string)value, typeName, limits.MaxStringLength);
+        }
+
+        // Reference-cycle detection for reference types only (boxed value types get a fresh box each
+        // time, so identity tracking there would never match and could false-positive on interned boxes).
+        if (!type.IsValueType && !visited.Add(value))
+        {
+            return new CapturedValue
+            {
+                Type = typeName,
+                Value = AlreadyCaptured,
+                NotCapturedReason = NotCapturedReason.AlreadyCaptured,
+            };
+        }
+
+        try
+        {
+            if (value is IDictionary dict)
+            {
+                if (collectionDepth >= limits.MaxCollectionDepth)
+                {
+                    return DepthLimited(typeName);
+                }
+
+                return SerializeDictionary(dict, typeName, limits, objectDepth, collectionDepth, visited);
+            }
+
+            if (value is IEnumerable enumerable && type != typeof(string))
+            {
+                if (collectionDepth >= limits.MaxCollectionDepth)
+                {
+                    return DepthLimited(typeName);
+                }
+
+                return SerializeCollection(enumerable, typeName, limits, objectDepth, collectionDepth, visited);
+            }
+
+            if (objectDepth >= limits.MaxObjectDepth)
+            {
+                return DepthLimited(typeName);
+            }
+
+            return SerializeObject(value, type, typeName, limits, objectDepth, collectionDepth, visited);
+        }
+        finally
+        {
+            // Remove on unwind so sibling references to the same object aren't false-positived as
+            // cycles — only ancestry (a value nested inside itself) counts as AlreadyCaptured.
+            if (!type.IsValueType)
+            {
+                visited.Remove(value);
+            }
+        }
+    }
+
+    private static CapturedValue DepthLimited(string typeName) =>
+        new() { Type = typeName, Value = DepthLimitReached, NotCapturedReason = NotCapturedReason.Depth };
+
+    private static bool IsPrimitive(Type type) =>
+        type.IsPrimitive || type == typeof(decimal) || type == typeof(DateTime)
+        || type == typeof(DateTimeOffset) || type == typeof(Guid) || type.IsEnum;
+
+    private static CapturedValue SerializePrimitive(object value, string typeName) =>
+        new() { Type = typeName, Value = value.ToString() };
+
+    private static CapturedValue SerializeString(string value, string typeName, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return new CapturedValue { Type = typeName, Value = value };
+        }
+
+        return new CapturedValue
+        {
+            Type = typeName,
+            Value = value[..maxLength],
+            Truncated = true,
+        };
+    }
+
+    private static CapturedValue SerializeCollection(IEnumerable enumerable, string typeName, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
+    {
+        var elements = new List<CapturedValue>();
+        int count = 0;
+        int totalCount = 0;
+
+        foreach (var item in enumerable)
+        {
+            totalCount++;
+            if (count < limits.MaxCollectionWidth)
+            {
+                elements.Add(Serialize(item, limits, objectDepth, collectionDepth + 1, visited));
+                count++;
+            }
+        }
+
+        var collectionTruncated = totalCount > limits.MaxCollectionWidth;
+        return new CapturedValue
+        {
+            Type = typeName,
+            Elements = elements.ToArray(),
+            OriginalSize = collectionTruncated ? totalCount : null,
+            NotCapturedReason = collectionTruncated ? NotCapturedReason.CollectionSize : NotCapturedReason.None,
+        };
+    }
+
+    private static CapturedValue SerializeDictionary(IDictionary dict, string typeName, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
+    {
+        var fields = new Dictionary<string, CapturedValue>();
+        int count = 0;
+
+        foreach (DictionaryEntry entry in dict)
+        {
+            if (count >= limits.MaxCollectionWidth)
+            {
+                break;
+            }
+
+            var key = entry.Key?.ToString() ?? "null";
+            fields[key] = Serialize(entry.Value, limits, objectDepth, collectionDepth + 1, visited);
+            count++;
+        }
+
+        var dictTruncated = dict.Count > limits.MaxCollectionWidth;
+        return new CapturedValue
+        {
+            Type = typeName,
+            Fields = fields,
+            OriginalSize = dictTruncated ? dict.Count : null,
+            NotCapturedReason = dictTruncated ? NotCapturedReason.CollectionSize : NotCapturedReason.None,
+        };
+    }
+
+    private static CapturedValue SerializeObject(object value, Type type, string typeName, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
+    {
+        var fields = new Dictionary<string, CapturedValue>();
+        int count = 0;
+        bool fieldCountExceeded = false;
+
+        try
+        {
+            var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+            foreach (var field in type.GetFields(bindingFlags))
+            {
+                if (count >= limits.MaxFieldsPerObject)
+                {
+                    fieldCountExceeded = true;
+                    break;
+                }
+
+                try
+                {
+                    var fieldValue = field.GetValue(value);
+                    fields[field.Name] = Serialize(fieldValue, limits, objectDepth + 1, collectionDepth, visited);
+                    count++;
+                }
+                catch
+                {
+                    fields[field.Name] = new CapturedValue { Type = "error", Value = "<access error>" };
+                    count++;
+                }
+            }
+
+            foreach (var prop in type.GetProperties(bindingFlags))
+            {
+                if (count >= limits.MaxFieldsPerObject)
+                {
+                    fieldCountExceeded = true;
+                    break;
+                }
+
+                if (!prop.CanRead || prop.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var propValue = prop.GetValue(value);
+                    fields[prop.Name] = Serialize(propValue, limits, objectDepth + 1, collectionDepth, visited);
+                    count++;
+                }
+                catch
+                {
+                    fields[prop.Name] = new CapturedValue { Type = "error", Value = "<access error>" };
+                    count++;
+                }
+            }
+        }
+        catch
+        {
+            return new CapturedValue { Type = typeName, Value = value.ToString() };
+        }
+
+        return new CapturedValue
+        {
+            Type = typeName,
+            Fields = fields,
+            NotCapturedReason = fieldCountExceeded ? NotCapturedReason.FieldCount : NotCapturedReason.None,
+        };
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/ValueSerializer.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/ValueSerializer.cs
@@ -120,27 +120,36 @@ internal static class ValueSerializer
 
     private static CapturedValue SerializeCollection(IEnumerable enumerable, string typeName, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
     {
-        var elements = new List<CapturedValue>();
-        int count = 0;
-        int totalCount = 0;
+        // Use ICollection.Count when available to avoid enumerating just to learn the size.
+        var knownCount = enumerable switch
+        {
+            ICollection c => c.Count,
+            _ => (int?)null,
+        };
 
+        var elements = new List<CapturedValue>();
+        int width = limits.MaxCollectionWidth;
+
+        // Pull at most width+1 (width to capture, +1 to detect truncation) — never walk the whole
+        // sequence, which may be huge/lazy/infinite and runs on the user's thread.
         foreach (var item in enumerable)
         {
-            totalCount++;
-            if (count < limits.MaxCollectionWidth)
+            if (elements.Count >= width)
             {
-                elements.Add(Serialize(item, limits, objectDepth, collectionDepth + 1, visited));
-                count++;
+                knownCount ??= width + 1; // Unknown size: one extra item proves there's more.
+                break;
             }
+
+            elements.Add(Serialize(item, limits, objectDepth, collectionDepth + 1, visited));
         }
 
-        var collectionTruncated = totalCount > limits.MaxCollectionWidth;
+        var truncated = knownCount is int n && n > width;
         return new CapturedValue
         {
             Type = typeName,
             Elements = elements.ToArray(),
-            OriginalSize = collectionTruncated ? totalCount : null,
-            NotCapturedReason = collectionTruncated ? NotCapturedReason.CollectionSize : NotCapturedReason.None,
+            OriginalSize = truncated ? knownCount : null,
+            NotCapturedReason = truncated ? NotCapturedReason.CollectionSize : NotCapturedReason.None,
         };
     }
 

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/ValueSerializer.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Capture/ValueSerializer.cs
@@ -65,14 +65,20 @@ internal static class ValueSerializer
                 return SerializeDictionary(dict, typeName, limits, objectDepth, collectionDepth, visited);
             }
 
-            if (value is IEnumerable enumerable && type != typeof(string))
+            // Only treat as a collection when the size is known in O(1). A countless/lazy IEnumerable is
+            // serialized as an object instead — walking it could be unbounded (or infinite) on the user's
+            // thread, and reporting a pulled-item count as the size would be a misleading lower bound, not
+            // the real length (matches Java/Python). The count comes from non-generic ICollection (arrays,
+            // List<T>) or, for sets that implement only the generic interface (HashSet<T>, SortedSet<T>),
+            // from ICollection<T>/IReadOnlyCollection<T>.
+            if (value is IEnumerable sequence && type != typeof(string) && TryGetKnownCount(value, out var knownCount))
             {
                 if (collectionDepth >= limits.MaxCollectionDepth)
                 {
                     return DepthLimited(typeName);
                 }
 
-                return SerializeCollection(enumerable, typeName, limits, objectDepth, collectionDepth, visited);
+                return SerializeCollection(sequence, knownCount, typeName, limits, objectDepth, collectionDepth, visited);
             }
 
             if (objectDepth >= limits.MaxObjectDepth)
@@ -118,37 +124,81 @@ internal static class ValueSerializer
         };
     }
 
-    private static CapturedValue SerializeCollection(IEnumerable enumerable, string typeName, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
+    // True only when the element count is available in O(1): non-generic ICollection (arrays, List<T>,
+    // Queue<T>, Stack<T>) or the generic ICollection<T>/IReadOnlyCollection<T> that sets implement without
+    // the non-generic one (HashSet<T>, SortedSet<T>). A bare IEnumerable has no size and returns false, so
+    // it is never walked as a collection. Count is read via the interface's own Count property — no enumeration.
+    private static bool TryGetKnownCount(object value, out int count)
     {
-        // Use ICollection.Count when available to avoid enumerating just to learn the size.
-        var knownCount = enumerable switch
+        // Any Count getter here belongs to a user type and runs on the user's thread. A throwing or
+        // unavailable getter (lazy/remote-backed collections, disposed views, thread-affinity violations)
+        // must NOT propagate — it would escape Serialize (which has only a finally, no catch) and abort the
+        // whole invocation's capture. On any failure we treat the value as countless and let it fall through
+        // to SerializeObject, whose per-field catches contain any further damage.
+        try
         {
-            ICollection c => c.Count,
-            _ => (int?)null,
-        };
-
-        var elements = new List<CapturedValue>();
-        int width = limits.MaxCollectionWidth;
-
-        // Pull at most width+1 (width to capture, +1 to detect truncation) — never walk the whole
-        // sequence, which may be huge/lazy/infinite and runs on the user's thread.
-        foreach (var item in enumerable)
-        {
-            if (elements.Count >= width)
+            if (value is ICollection nonGeneric)
             {
-                knownCount ??= width + 1; // Unknown size: one extra item proves there's more.
-                break;
+                count = nonGeneric.Count;
+                return true;
             }
 
-            elements.Add(Serialize(item, limits, objectDepth, collectionDepth + 1, visited));
+            foreach (var iface in value.GetType().GetInterfaces())
+            {
+                if (iface.IsGenericType)
+                {
+                    var def = iface.GetGenericTypeDefinition();
+                    if (def == typeof(ICollection<>) || def == typeof(IReadOnlyCollection<>))
+                    {
+                        count = (int)iface.GetProperty("Count")!.GetValue(value)!;
+                        return true;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Fall through to countless.
         }
 
-        var truncated = knownCount is int n && n > width;
+        count = 0;
+        return false;
+    }
+
+    private static CapturedValue SerializeCollection(IEnumerable collection, int totalCount, string typeName, CaptureConfiguration limits, int objectDepth, int collectionDepth, HashSet<object> visited)
+    {
+        // Size is known O(1) (resolved by the caller via TryGetKnownCount), so we capture only the first
+        // MaxCollectionWidth items and report the true total — never enumerate past the cap on the user's thread.
+        int width = limits.MaxCollectionWidth;
+
+        var elements = new List<CapturedValue>();
+
+        // Enumeration runs on the user's thread over a possibly-live collection. If another thread mutates
+        // it mid-walk the enumerator throws (InvalidOperationException: "collection was modified"); keep what
+        // was captured so far rather than letting it escape Serialize and abort the whole invocation.
+        try
+        {
+            foreach (var item in collection)
+            {
+                if (elements.Count >= width)
+                {
+                    break;
+                }
+
+                elements.Add(Serialize(item, limits, objectDepth, collectionDepth + 1, visited));
+            }
+        }
+        catch
+        {
+            // Partial capture stands.
+        }
+
+        var truncated = totalCount > width;
         return new CapturedValue
         {
             Type = typeName,
             Elements = elements.ToArray(),
-            OriginalSize = truncated ? knownCount : null,
+            OriginalSize = truncated ? totalCount : null,
             NotCapturedReason = truncated ? NotCapturedReason.CollectionSize : NotCapturedReason.None,
         };
     }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/ConfigurationPoller.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/ConfigurationPoller.cs
@@ -1,14 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Text.Json;
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
 
 namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Client;
 
-/// <summary>
-/// Polls the configuration API on background threads (one for probes, one for breakpoints),
-/// applying backoff and change detection, and invoking a callback when the active set changes.
-/// </summary>
+/// <summary>Polls the configuration API on background threads, applying backoff and change detection, and invoking a callback when the active set changes.</summary>
 /// <param name="client">The API client used to fetch configurations.</param>
 /// <param name="probeIntervalSeconds">Base interval between probe polls.</param>
 /// <param name="breakpointIntervalSeconds">Base interval between breakpoint polls.</param>
@@ -37,8 +35,9 @@ public sealed class ConfigurationPoller(
     private Thread? probeThread;
     private Thread? breakpointThread;
 
-    private string? probeSyncedAt;
-    private string? breakpointSyncedAt;
+    // Opaque sync cursors echoed back to the backend; JsonElement because the live backend sends SyncedAt as an epoch-seconds number, not the spec's ISO string.
+    private JsonElement? probeSyncedAt;
+    private JsonElement? breakpointSyncedAt;
 
     // TODO: staleness tracking — force full resync when no success for 30m (probes) / 5m (breakpoints)
     private HashSet<string> lastFingerprint = [];
@@ -62,7 +61,7 @@ public sealed class ConfigurationPoller(
     /// <summary>Disposes the poller. Threads exit when the cancellation token is cancelled.</summary>
     public void Dispose()
     {
-        // Threads exit when CancellationToken is cancelled (managed externally)
+        // Threads exit when the (externally managed) CancellationToken is cancelled.
     }
 
     // Degrade only after all backoff tiers are used (> not >=, else the last tier is skipped).
@@ -135,8 +134,7 @@ public sealed class ConfigurationPoller(
     private async Task<bool> FetchAndApply(InstrumentationType type)
     {
         var syncedAt = type == InstrumentationType.PROBE ? this.probeSyncedAt : this.breakpointSyncedAt;
-        var response = await this.client.FetchConfigurationsAsync(
-            type, string.IsNullOrEmpty(syncedAt) ? null : syncedAt, this.ct);
+        var response = await this.client.FetchConfigurationsAsync(type, syncedAt, this.ct);
 
         if (!response.Success)
         {
@@ -148,7 +146,6 @@ public sealed class ConfigurationPoller(
             return true;
         }
 
-        // Update SyncedAt
         if (type == InstrumentationType.PROBE)
         {
             this.probeSyncedAt = response.SyncedAt;
@@ -158,7 +155,6 @@ public sealed class ConfigurationPoller(
             this.breakpointSyncedAt = response.SyncedAt;
         }
 
-        // Parse configurations
         var configs = response.Configurations
             .Select(InstrumentationConfiguration.Parse)
             .Where(c => c != null)
@@ -167,6 +163,7 @@ public sealed class ConfigurationPoller(
 
         // Update cache and merge — snapshot under lock, invoke callback outside
         List<InstrumentationConfiguration> snapshot;
+        HashSet<string> fingerprint;
         lock (this.configLock)
         {
             if (type == InstrumentationType.PROBE)
@@ -180,8 +177,8 @@ public sealed class ConfigurationPoller(
 
             var allConfigs = this.cachedProbeConfigs.Concat(this.cachedBreakpointConfigs).ToList();
 
-            // Fingerprint check — skip if unchanged
-            var fingerprint = new HashSet<string>(
+            // Fingerprint check — skip if unchanged.
+            fingerprint = new HashSet<string>(
                 allConfigs.Select(c => $"{c.LocationHash}:{c.CreatedAt?.ToUnixTimeMilliseconds()}"));
 
             if (fingerprint.SetEquals(this.lastFingerprint))
@@ -189,11 +186,12 @@ public sealed class ConfigurationPoller(
                 return true;
             }
 
-            this.lastFingerprint = fingerprint;
             snapshot = allConfigs;
         }
 
+        // Persist the fingerprint only after the callback succeeds; if it throws, the stale fingerprint forces the next poll to re-apply instead of silently dropping the change.
         this.onConfigurationsChanged(snapshot);
+        this.lastFingerprint = fingerprint;
         return true;
     }
 

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/ConfigurationPoller.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/ConfigurationPoller.cs
@@ -146,14 +146,11 @@ public sealed class ConfigurationPoller(
             return true;
         }
 
-        if (type == InstrumentationType.PROBE)
-        {
-            this.probeSyncedAt = response.SyncedAt;
-        }
-        else
-        {
-            this.breakpointSyncedAt = response.SyncedAt;
-        }
+        // The cursor is committed only AFTER a fully-applied set (below), never here. Advancing it up front
+        // would tell the backend "consumed" for a config whose apply returned false (e.g. type not loaded
+        // yet); the next poll would then return Changed=false and short-circuit, so the retry would never
+        // run and the probe would stay dead until an unrelated change flipped Changed=true.
+        var newSyncedAt = response.SyncedAt;
 
         var configs = response.Configurations
             .Select(InstrumentationConfiguration.Parse)
@@ -183,20 +180,38 @@ public sealed class ConfigurationPoller(
 
             if (fingerprint.SetEquals(this.lastFingerprint))
             {
+                // Nothing to apply (effective set unchanged) — safe to advance the cursor.
+                this.CommitCursor(type, newSyncedAt);
                 return true;
             }
 
             snapshot = allConfigs;
         }
 
-        // Latch the fingerprint only when the callback fully applied the set. A throw or a false result
-        // (some target not applyable yet) leaves it stale so the next poll re-invokes and retries.
+        // Commit the fingerprint AND the cursor only when the callback fully applied the set. A throw or a
+        // false result (some target not applyable yet) leaves both stale, so the next poll re-fetches the
+        // same set (cursor not advanced) and re-invokes (fingerprint not latched) — retrying until it loads.
         if (this.onConfigurationsChanged(snapshot))
         {
             this.lastFingerprint = fingerprint;
+            this.CommitCursor(type, newSyncedAt);
         }
 
         return true;
+    }
+
+    // Advances the per-type sync cursor. Called only on a fully-applied (or nothing-to-apply) result, so a
+    // config that could not be applied yet is re-fetched next poll instead of being marked consumed.
+    private void CommitCursor(InstrumentationType type, System.Text.Json.JsonElement? syncedAt)
+    {
+        if (type == InstrumentationType.PROBE)
+        {
+            this.probeSyncedAt = syncedAt;
+        }
+        else
+        {
+            this.breakpointSyncedAt = syncedAt;
+        }
     }
 
     private void WaitWithCancellation(int ms)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/ConfigurationPoller.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/ConfigurationPoller.cs
@@ -10,13 +10,13 @@ namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Client;
 /// <param name="client">The API client used to fetch configurations.</param>
 /// <param name="probeIntervalSeconds">Base interval between probe polls.</param>
 /// <param name="breakpointIntervalSeconds">Base interval between breakpoint polls.</param>
-/// <param name="onConfigurationsChanged">Callback invoked with the merged active configuration set.</param>
+/// <param name="onConfigurationsChanged">Callback invoked with the merged active configuration set. Returns true when the set was fully applied and the change may be latched; false when some target could not be applied yet (e.g. its assembly is not loaded) and the next poll should re-invoke to retry.</param>
 /// <param name="ct">Cancellation token that stops the poll loops.</param>
 public sealed class ConfigurationPoller(
     DynamicInstrumentationClient client,
     int probeIntervalSeconds,
     int breakpointIntervalSeconds,
-    Action<List<InstrumentationConfiguration>> onConfigurationsChanged,
+    Func<List<InstrumentationConfiguration>, bool> onConfigurationsChanged,
     CancellationToken ct) : IDisposable
 {
     private const int DegradedIntervalMs = 300_000;
@@ -28,7 +28,7 @@ public sealed class ConfigurationPoller(
     private readonly DynamicInstrumentationClient client = client;
     private readonly int probeIntervalMs = ToIntervalMs(probeIntervalSeconds);
     private readonly int breakpointIntervalMs = ToIntervalMs(breakpointIntervalSeconds);
-    private readonly Action<List<InstrumentationConfiguration>> onConfigurationsChanged = onConfigurationsChanged;
+    private readonly Func<List<InstrumentationConfiguration>, bool> onConfigurationsChanged = onConfigurationsChanged;
     private readonly CancellationToken ct = ct;
     private readonly object configLock = new();
 
@@ -189,9 +189,13 @@ public sealed class ConfigurationPoller(
             snapshot = allConfigs;
         }
 
-        // Persist the fingerprint only after the callback succeeds; if it throws, the stale fingerprint forces the next poll to re-apply instead of silently dropping the change.
-        this.onConfigurationsChanged(snapshot);
-        this.lastFingerprint = fingerprint;
+        // Latch the fingerprint only when the callback fully applied the set. A throw or a false result
+        // (some target not applyable yet) leaves it stale so the next poll re-invokes and retries.
+        if (this.onConfigurationsChanged(snapshot))
+        {
+            this.lastFingerprint = fingerprint;
+        }
+
         return true;
     }
 

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/DynamicInstrumentationClient.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/DynamicInstrumentationClient.cs
@@ -23,7 +23,12 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
 {
     private const int MaxPages = 3;
 
-    // PascalCase on the wire (no camelCase policy) to match the API and the other SDKs.
+    // Prefix on DI log lines so operators can grep the agent's output apart from the host app's.
+    private const string LogPrefix = "AWS DI: ";
+
+    private const string UserAgent = "DynamicInstrumentationClient/1.0";
+
+    // PascalCase on the wire (no camelCase policy) to match the API.
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         Converters = { new JsonStringEnumConverter() },
@@ -42,11 +47,11 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The fetch result, including whether anything changed.</returns>
     public async Task<FetchConfigurationsResponse> FetchConfigurationsAsync(
-        InstrumentationType type, string? syncedAt = null, CancellationToken ct = default)
+        InstrumentationType type, JsonElement? syncedAt = null, CancellationToken ct = default)
     {
         var allConfigs = new List<JsonElement>();
         string? nextToken = null;
-        string? responseSyncedAt = null;
+        JsonElement? responseSyncedAt = null;
         var changed = false;
         int? syncInterval = null;
 
@@ -61,22 +66,32 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
                 NextToken = nextToken,
             };
 
-            var response = await this.PostAsync<FetchConfigurationsRequest, FetchConfigurationsRawResponse>(
-                $"{this.apiUrl}/list-instrumentation-configurations", request, ct);
+            var (response, notFound) = await this.PostAsync<FetchConfigurationsRequest, FetchConfigurationsRawResponse>(
+                $"{this.apiUrl.TrimEnd('/')}/list-instrumentation-configurations", request, ct);
+
+            // 404 means "no configs for this service/env" — a normal empty result, not a failure.
+            if (notFound)
+            {
+                return new FetchConfigurationsResponse(true, page == 0 ? false : changed, responseSyncedAt, syncInterval, [.. allConfigs]);
+            }
 
             if (response == null)
             {
                 return FetchConfigurationsResponse.Failed;
             }
 
-            // Latch `changed` from page 0 only — a later page's Changed=false must not
-            // drop configs already accumulated (data loss).
+            // Latch `changed` from page 0 only — a later page's Changed=false must not drop accumulated configs.
             if (page == 0)
             {
                 changed = response.Changed;
             }
 
-            responseSyncedAt = response.SyncedAt;
+            // Only carry a real cursor forward; an absent SyncedAt (Undefined) must not be echoed back.
+            if (response.SyncedAt.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null)
+            {
+                responseSyncedAt = response.SyncedAt.Clone();
+            }
+
             syncInterval = response.SyncInterval;
 
             if (!changed)
@@ -118,29 +133,42 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
         };
 
         await this.PostAsync<ReportStatusRequest, object>(
-            $"{this.apiUrl}/report-instrumentation-configuration-status", request, ct);
+            $"{this.apiUrl.TrimEnd('/')}/report-instrumentation-configuration-status", request, ct);
     }
 
-    private async Task<TResponse?> PostAsync<TRequest, TResponse>(string url, TRequest body, CancellationToken ct)
+    // Returns (deserialized response, notFound). notFound=true distinguishes a 404 (normal empty result) from other failures.
+    private async Task<(TResponse? Response, bool NotFound)> PostAsync<TRequest, TResponse>(string url, TRequest body, CancellationToken ct)
     {
         try
         {
             using var suppressScope = SuppressInstrumentationScope.Begin();
 
-            var response = await this.httpClient.PostAsJsonAsync(url, body, JsonOptions, ct);
+            // Not disposed: content must stay readable after SendAsync returns; disposal is non-critical here.
+            var message = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = JsonContent.Create(body, options: JsonOptions),
+            };
+            message.Headers.TryAddWithoutValidation("User-Agent", UserAgent);
+
+            var response = await this.httpClient.SendAsync(message, ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return (default, true);
+            }
 
             if (!response.IsSuccessStatusCode)
             {
-                return default;
+                return (default, false);
             }
 
             var content = await response.Content.ReadAsStringAsync(ct);
             if (string.IsNullOrEmpty(content))
             {
-                return default;
+                return (default, false);
             }
 
-            return JsonSerializer.Deserialize<TResponse>(content, JsonOptions);
+            return (JsonSerializer.Deserialize<TResponse>(content, JsonOptions), false);
         }
         catch (OperationCanceledException)
         {
@@ -148,7 +176,7 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
         }
         catch (Exception ex)
         {
-            this.log.LogDebug(ex, "DI client request to {Url} failed", url);
+            this.log.LogDebug(ex, LogPrefix + "client request to {Url} failed", url);
             return default;
         }
     }
@@ -168,8 +196,8 @@ public record FetchConfigurationsRequest
     /// <summary>Gets the instrumentation type being requested.</summary>
     public string InstrumentationType { get; init; } = string.Empty;
 
-    /// <summary>Gets the opaque sync cursor from the previous response, if any.</summary>
-    public string? SyncedAt { get; init; }
+    /// <summary>Gets the sync cursor echoed back verbatim (a JSON number on the live backend); omitted on a full sync.</summary>
+    public JsonElement? SyncedAt { get; init; }
 
     /// <summary>Gets the pagination token, if continuing a prior page.</summary>
     public string? NextToken { get; init; }
@@ -184,7 +212,7 @@ public record FetchConfigurationsRequest
 public record FetchConfigurationsResponse(
     bool Success,
     bool Changed,
-    string? SyncedAt,
+    JsonElement? SyncedAt,
     int? SyncInterval,
     JsonElement[] Configurations)
 {
@@ -200,20 +228,20 @@ public record StatusEntry
     /// <summary>Gets the instrumentation type.</summary>
     public string InstrumentationType { get; init; } = string.Empty;
 
+    /// <summary>Gets the signal type. Only "SNAPSHOT" is emitted, matching the other SDKs.</summary>
+    public string SignalType { get; init; } = "SNAPSHOT";
+
     /// <summary>Gets the location hash identifying the configuration.</summary>
     public string LocationHash { get; init; } = string.Empty;
 
     /// <summary>Gets the status value (e.g. READY, ACTIVE, ERROR, DISABLED).</summary>
     public string Status { get; init; } = string.Empty;
 
-    /// <summary>Gets the disable reason, if the status is DISABLED.</summary>
-    public string? DisableReason { get; init; }
-
     /// <summary>Gets the error cause, if the status is ERROR.</summary>
     public string? ErrorCause { get; init; }
 
-    /// <summary>Gets the timestamp of the status event.</summary>
-    public string? Timestamp { get; init; }
+    /// <summary>Gets the status event time as Unix epoch seconds (wire contract, matches other SDKs).</summary>
+    public long Time { get; init; }
 }
 
 /// <summary>Raw deserialized response for a single page of the list API.</summary>
@@ -223,9 +251,9 @@ internal record FetchConfigurationsRawResponse
     [JsonPropertyName("Changed")]
     public bool Changed { get; init; }
 
-    /// <summary>Gets the opaque cursor token (ISO-8601 string per spec) — echoed back, never parsed.</summary>
+    /// <summary>Gets the raw sync cursor; the live backend emits a JSON number (epoch seconds), captured as <see cref="JsonElement"/> and only echoed back.</summary>
     [JsonPropertyName("SyncedAt")]
-    public string? SyncedAt { get; init; }
+    public JsonElement SyncedAt { get; init; }
 
     /// <summary>Gets the server-suggested seconds to wait before the next sync.</summary>
     [JsonPropertyName("SyncInterval")]

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/DynamicInstrumentationClient.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/DynamicInstrumentationClient.cs
@@ -143,14 +143,16 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
         {
             using var suppressScope = SuppressInstrumentationScope.Begin();
 
-            // Not disposed: content must stay readable after SendAsync returns; disposal is non-critical here.
-            var message = new HttpRequestMessage(HttpMethod.Post, url)
+            // Disposed once the exchange completes: the request content is consumed by SendAsync and the
+            // response body is fully buffered by ReadAsStringAsync below before we return, so nothing here
+            // is read afterwards. `using` also disposes the request Content (the JsonContent stream).
+            using var message = new HttpRequestMessage(HttpMethod.Post, url)
             {
                 Content = JsonContent.Create(body, options: JsonOptions),
             };
             message.Headers.TryAddWithoutValidation("User-Agent", UserAgent);
 
-            var response = await this.httpClient.SendAsync(message, ct);
+            using var response = await this.httpClient.SendAsync(message, ct);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/DynamicInstrumentationClient.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Client/DynamicInstrumentationClient.cs
@@ -69,10 +69,18 @@ public class DynamicInstrumentationClient(HttpClient httpClient, string apiUrl, 
             var (response, notFound) = await this.PostAsync<FetchConfigurationsRequest, FetchConfigurationsRawResponse>(
                 $"{this.apiUrl.TrimEnd('/')}/list-instrumentation-configurations", request, ct);
 
-            // 404 means "no configs for this service/env" — a normal empty result, not a failure.
             if (notFound)
             {
-                return new FetchConfigurationsResponse(true, page == 0 ? false : changed, responseSyncedAt, syncInterval, [.. allConfigs]);
+                // On page 0, a 404 means "no configs for this service/env" — a normal empty, unchanged result.
+                if (page == 0)
+                {
+                    return new FetchConfigurationsResponse(true, false, responseSyncedAt, syncInterval, [.. allConfigs]);
+                }
+
+                // On a later page, a 404 is a transient paging failure, NOT a removal. Returning the
+                // partial page-0 set as a complete Changed=true result would make the caller diff it and
+                // tear down every not-yet-fetched probe. Abandon the whole fetch and keep the current cache.
+                return FetchConfigurationsResponse.Failed;
             }
 
             if (response == null)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Config/DynamicInstrumentationConfig.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Config/DynamicInstrumentationConfig.cs
@@ -34,7 +34,9 @@ public sealed record DynamicInstrumentationConfig(
         var apiUrl = GetString($"{Prefix}API_URL", "http://localhost:2000");
         var probePoll = Math.Max(MinPollIntervalSeconds, GetInt($"{Prefix}PROBE_POLL_INTERVAL", 600));
         var breakpointPoll = Math.Max(MinPollIntervalSeconds, GetInt($"{Prefix}BREAKPOINT_POLL_INTERVAL", 60));
-        var logsEndpoint = GetString($"{Prefix}LOGS_ENDPOINT", null);
+
+        // Cross-SDK env var (NOT under the DI prefix) — matches the Java/Python/JS agents.
+        var logsEndpoint = GetString("OTEL_AWS_OTLP_LOGS_ENDPOINT", null);
         var serviceName = ResolveServiceName();
         var environment = ResolveEnvironment();
 
@@ -81,7 +83,7 @@ public sealed record DynamicInstrumentationConfig(
     private static bool GetBool(string name, bool defaultValue)
     {
         var val = System.Environment.GetEnvironmentVariable(name);
-        return val != null ? val.Equals("true", StringComparison.OrdinalIgnoreCase) : defaultValue;
+        return val != null ? val.Trim().Equals("true", StringComparison.OrdinalIgnoreCase) : defaultValue;
     }
 
     private static string GetString(string name, string? defaultValue) =>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
@@ -3,6 +3,8 @@
 
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Client;
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Config;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
 using OpenTelemetry.Trace;
 
@@ -17,6 +19,13 @@ public sealed class DynamicInstrumentationManager : IDisposable
     private static readonly Lazy<DynamicInstrumentationManager> LazyInstance = new(() => new DynamicInstrumentationManager());
 
     private readonly object initLock = new();
+
+    // Serializes OnConfigurationsChanged: the poller calls it from both poll threads. Lock order is always initLock -> configChangeLock.
+    private readonly object configChangeLock = new();
+
+    // Configs already handed to the profiler; applied once each. Cleared on Cleanup (C3). Guarded by configChangeLock.
+    private readonly HashSet<string> appliedInstrumentations = new();
+
     private volatile bool initialized;
     private DynamicInstrumentationConfig? config;
     private CancellationTokenSource? cts;
@@ -25,8 +34,11 @@ public sealed class DynamicInstrumentationManager : IDisposable
     private DynamicInstrumentationClient? client;
     private ConfigurationPoller? poller;
 
-    // TODO (PR 2): InstrumentationRegistry, ProfilerTranslator fields
-    // TODO (PR 3): DISnapshotCollector, DISnapshotOtlpEmitter, StatusReporter fields
+    // Capture engine: registry of active instrumentations + profiler translator.
+    private InstrumentationRegistry? registry;
+    private ProfilerTranslator? profilerTranslator;
+
+    // Output subsystems (snapshot drain + status reporting) land in PR3.
     private DynamicInstrumentationManager()
     {
     }
@@ -40,11 +52,13 @@ public sealed class DynamicInstrumentationManager : IDisposable
     /// <summary>Gets the active configuration, if initialized.</summary>
     public DynamicInstrumentationConfig? Config => this.config;
 
+    /// <summary>Gets the registry of active instrumentations, or null before initialization.</summary>
+    internal InstrumentationRegistry? Registry => this.registry;
+
     /// <summary>Hook invoked once the TracerProvider is built. Currently a no-op.</summary>
     /// <param name="provider">The initialized tracer provider.</param>
     public static void OnTracerProviderInitialized(TracerProvider provider)
     {
-        // TracerProvider available — could extract Resource attributes if needed.
     }
 
     /// <summary>Initializes the manager and starts configuration polling. Idempotent.</summary>
@@ -70,12 +84,18 @@ public sealed class DynamicInstrumentationManager : IDisposable
 
             try
             {
-                // 1. HTTP Client
                 this.httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
                 this.client = new DynamicInstrumentationClient(
                     this.httpClient, config.ApiUrl, config.ServiceName, config.Environment);
 
-                // 2. Configuration Poller (starts 2 background threads)
+                // Capture engine must exist before the poller starts, or the first poll hits a null registry.
+                this.registry = new InstrumentationRegistry();
+                this.profilerTranslator = new ProfilerTranslator();
+                DiIntegrationHelper.Configure(this.registry);
+
+                // Output subsystems (drain + status reporting) land in PR3.
+
+                // Poller started last so its OnConfigurationsChanged dependencies are all live.
                 this.poller = new ConfigurationPoller(
                     this.client,
                     config.ProbePollIntervalSeconds,
@@ -84,11 +104,6 @@ public sealed class DynamicInstrumentationManager : IDisposable
                     this.cts.Token);
                 this.poller.Start();
 
-                // TODO: InstrumentationRegistry (PR 2)
-                // TODO: ProfilerTranslator + DiIntegrationHelper (PR 2)
-                // TODO: DISnapshotCollector (PR 3)
-                // TODO: DISnapshotOtlpEmitter (PR 3)
-                // TODO: StatusReporter (PR 3)
                 this.initialized = true;
             }
             catch (Exception)
@@ -127,13 +142,92 @@ public sealed class DynamicInstrumentationManager : IDisposable
     }
 
     /// <summary>
-    /// Called by <see cref="ConfigurationPoller"/> when the active configuration set changes.
-    /// PR 2 will wire the registry and profiler translator here.
+    /// Called by <see cref="ConfigurationPoller"/> on config change: registers supported targets, removes stale ones, and applies each new config to the profiler once.
     /// </summary>
     /// <param name="configs">The merged active configuration set.</param>
     internal void OnConfigurationsChanged(List<InstrumentationConfiguration> configs)
     {
-        // TODO (PR 2): Register configs, apply via ProfilerTranslator, remove stale
+        // Serialize the callback: the poller drives it from both poll threads.
+        lock (this.configChangeLock)
+        {
+            this.OnConfigurationsChangedLocked(configs);
+        }
+    }
+
+    /// <summary>
+    /// A config is supported when it is method-level and not an unsupported target
+    /// (constructors/static constructors, which the profiler cannot weave here).
+    /// </summary>
+    private static bool IsSupported(InstrumentationConfiguration config) =>
+        config.IsMethodLevel && !ProfilerTranslator.IsUnsupportedTarget(config);
+
+    private void OnConfigurationsChangedLocked(List<InstrumentationConfiguration> configs)
+    {
+        var reg = this.registry;
+        if (reg == null)
+        {
+            return;
+        }
+
+        // Register only supported targets; unsupported ones never enter the registry.
+        var activeKeys = new HashSet<string>();
+        foreach (var config in configs)
+        {
+            if (!IsSupported(config))
+            {
+                // Report refused method-level targets (ctor/static-init); skip line-level silently to avoid status spam.
+                if (config.IsMethodLevel)
+                {
+                    // TODO(PR3): this.statusReporter.ReportError(config, "UNSUPPORTED_TARGET");
+                }
+
+                continue;
+            }
+
+            activeKeys.Add(config.InstrumentationKey);
+            reg.Register(config);
+        }
+
+        // Drop stale configs and forget their applied-state so a re-add re-applies them.
+        foreach (var removedKey in reg.RemoveStale(activeKeys))
+        {
+            this.appliedInstrumentations.Remove(removedKey);
+        }
+
+        // Apply each newly-registered config to the profiler exactly once.
+        foreach (var registered in reg.GetAll())
+        {
+            var config = registered.Config;
+            var key = config.InstrumentationKey;
+            if (!this.appliedInstrumentations.Add(key))
+            {
+                continue; // Already applied on a previous poll.
+            }
+
+            var result = this.profilerTranslator?.ApplyInstrumentation(config)
+                ?? InstrumentationApplyResult.TypeNotLoaded;
+            switch (result)
+            {
+                case InstrumentationApplyResult.Applied:
+                    // TODO(PR3): this.statusReporter.ReportReadyForNew();
+                    break;
+
+                case InstrumentationApplyResult.TypeNotLoaded:
+                    // Target assembly likely not loaded yet; forget applied-state so a later poll retries. No ERROR (would spam every poll).
+                    this.appliedInstrumentations.Remove(key);
+                    break;
+
+                case InstrumentationApplyResult.Skipped:
+                    // Unsupported slipped past IsSupported (shouldn't happen); drop applied-state without reporting.
+                    this.appliedInstrumentations.Remove(key);
+                    break;
+
+                default:
+                    // Permanent failure: keep the key so we report it exactly once, not every poll.
+                    // TODO(PR3): this.statusReporter.ReportError(config, MapErrorCause(result));
+                    break;
+            }
+        }
     }
 
     private void Cleanup()
@@ -141,11 +235,20 @@ public sealed class DynamicInstrumentationManager : IDisposable
         this.poller?.Dispose();
         this.httpClient?.Dispose();
         this.cts?.Dispose();
+
         this.poller = null;
         this.client = null;
         this.httpClient = null;
 
-        // TODO (PR 2): nullify registry, profilerTranslator
-        // TODO (PR 3): dispose/nullify snapshotCollector, otlpEmitter, statusReporter
+        // Reset the capture engine; clear appliedInstrumentations with the registry so they don't diverge on restart (C3).
+        // configChangeLock guards against interleaving with an in-flight callback (order: initLock -> configChangeLock).
+        this.registry = null;
+        this.profilerTranslator = null;
+        lock (this.configChangeLock)
+        {
+            this.appliedInstrumentations.Clear();
+        }
+
+        DiIntegrationHelper.Configure(null);
     }
 }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
@@ -204,11 +204,26 @@ public sealed class DynamicInstrumentationManager : IDisposable
                 continue; // Already applied on a previous poll.
             }
 
-            var result = this.profilerTranslator?.ApplyInstrumentation(config)
+            IReadOnlyCollection<int> appliedArities = Array.Empty<int>();
+            var result = this.profilerTranslator?.ApplyInstrumentation(config, out appliedArities)
                 ?? InstrumentationApplyResult.TypeNotLoaded;
             switch (result)
             {
                 case InstrumentationApplyResult.Applied:
+                    // Index the woven arities so the capture hot path resolves this call by (type, arity),
+                    // disambiguating co-located methods that differ in parameter count (#3).
+                    if (reg.IndexArities(config.TypeName, key, appliedArities))
+                    {
+                        // Same-arity collision: another configured method on this type has the same
+                        // parameter count, so args.Length can't tell them apart — captures may be
+                        // attributed to the wrong probe. Documented #3 residual.
+                        // Note: this only fires for the SECOND (colliding) config to apply — the first
+                        // applied cleanly before its peer existed, so it's never flagged even though it's
+                        // equally ambiguous. TODO(PR3): report ERROR for BOTH keys sharing the bucket
+                        // (this.statusReporter.ReportError on each), not just this incoming one, or the
+                        // operator sees only half the ambiguous pair.
+                    }
+
                     // TODO(PR3): this.statusReporter.ReportReadyForNew();
                     break;
 

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
@@ -145,12 +145,13 @@ public sealed class DynamicInstrumentationManager : IDisposable
     /// Called by <see cref="ConfigurationPoller"/> on config change: registers supported targets, removes stale ones, and applies each new config to the profiler once.
     /// </summary>
     /// <param name="configs">The merged active configuration set.</param>
-    internal void OnConfigurationsChanged(List<InstrumentationConfiguration> configs)
+    /// <returns>True when every supported config was applied (safe for the poller to latch this set); false when at least one target could not be applied yet and the next poll should retry.</returns>
+    internal bool OnConfigurationsChanged(List<InstrumentationConfiguration> configs)
     {
         // Serialize the callback: the poller drives it from both poll threads.
         lock (this.configChangeLock)
         {
-            this.OnConfigurationsChangedLocked(configs);
+            return this.OnConfigurationsChangedLocked(configs);
         }
     }
 
@@ -161,12 +162,12 @@ public sealed class DynamicInstrumentationManager : IDisposable
     private static bool IsSupported(InstrumentationConfiguration config) =>
         config.IsMethodLevel && !ProfilerTranslator.IsUnsupportedTarget(config);
 
-    private void OnConfigurationsChangedLocked(List<InstrumentationConfiguration> configs)
+    private bool OnConfigurationsChangedLocked(List<InstrumentationConfiguration> configs)
     {
         var reg = this.registry;
         if (reg == null)
         {
-            return;
+            return true;
         }
 
         // Register only supported targets; unsupported ones never enter the registry.
@@ -193,6 +194,9 @@ public sealed class DynamicInstrumentationManager : IDisposable
         {
             this.appliedInstrumentations.Remove(removedKey);
         }
+
+        // If any target can't be applied yet, signal the poller not to latch so the next poll retries.
+        var retryNeeded = false;
 
         // Apply each newly-registered config to the profiler exactly once.
         foreach (var registered in reg.GetAll())
@@ -230,6 +234,8 @@ public sealed class DynamicInstrumentationManager : IDisposable
                 case InstrumentationApplyResult.TypeNotLoaded:
                     // Target assembly likely not loaded yet; forget applied-state so a later poll retries. No ERROR (would spam every poll).
                     this.appliedInstrumentations.Remove(key);
+
+                    retryNeeded = true; // Don't latch, or the fingerprint gate never revisits this config.
                     break;
 
                 case InstrumentationApplyResult.Skipped:
@@ -243,6 +249,9 @@ public sealed class DynamicInstrumentationManager : IDisposable
                     break;
             }
         }
+
+        // Latch only when nothing is pending a retry.
+        return !retryNeeded;
     }
 
     private void Cleanup()

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/DynamicInstrumentationManager.cs
@@ -190,6 +190,15 @@ public sealed class DynamicInstrumentationManager : IDisposable
         }
 
         // Drop stale configs and forget their applied-state so a re-add re-applies them.
+        //
+        // NOTE ON UNINSTRUMENTING: the profiler exposes no revert/remove export (no RequestRevert; the
+        // native ABI is AddInstrumentations only — see NativeMethods.cs), so we cannot un-weave a method
+        // whose IL was already rewritten. Removal is therefore a *logical* uninstrument: dropping the key
+        // from the registry makes the still-woven DiIntegration callback a no-op on its next invocation —
+        // registry.TryHit / registry.Get return false/null for the missing key, so OnMethodBegin returns
+        // CallTargetState.GetDefault() and OnMethodEnd finds no paired entry, enqueuing nothing. The method
+        // keeps the (cheap) woven prologue/epilogue that immediately short-circuits; no snapshot is ever
+        // produced for a removed config. Forgetting applied-state here also lets a later re-add re-apply it.
         foreach (var removedKey in reg.RemoveStale(activeKeys))
         {
             this.appliedInstrumentations.Remove(removedKey);
@@ -244,8 +253,12 @@ public sealed class DynamicInstrumentationManager : IDisposable
                     break;
 
                 default:
-                    // Permanent failure: keep the key so we report it exactly once, not every poll.
-                    // TODO(PR3): this.statusReporter.ReportError(config, MapErrorCause(result));
+                    // Permanent instrumentation failure (MethodNotFound / NoSupportedArity / RuntimeError):
+                    // keep the key in appliedInstrumentations so we report it EXACTLY ONCE, not every poll.
+                    // result.IsReportableFailure() is true here and result.MapErrorCause() gives the backend
+                    // ErrorCause. This is an instrumentation-level ERROR (the target couldn't be woven) — a
+                    // capture-level partial (NotCapturedReason) is emitted inside a snapshot instead, never here.
+                    // TODO(PR3): if (result.IsReportableFailure()) this.statusReporter.ReportError(config, result.MapErrorCause()!);
                     break;
             }
         }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration0.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration0.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 0 parameter(s).
+/// </summary>
+internal static class DiIntegration0
+{
+    internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, Array.Empty<object?>());
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration0.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration0.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration0
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration1.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration1.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 1 parameter(s).
+/// </summary>
+internal static class DiIntegration1
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1>(TTarget instance, TArg1 arg1)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration1.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration1.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration1
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration2.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration2.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 2 parameter(s).
+/// </summary>
+internal static class DiIntegration2
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2>(TTarget instance, TArg1 arg1, TArg2 arg2)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration2.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration2.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration2
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration3.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration3.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 3 parameter(s).
+/// </summary>
+internal static class DiIntegration3
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration3.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration3.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration3
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration4.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration4.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 4 parameter(s).
+/// </summary>
+internal static class DiIntegration4
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3, arg4 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration4.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration4.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration4
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration5.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration5.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 5 parameter(s).
+/// </summary>
+internal static class DiIntegration5
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3, arg4, arg5 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration5.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration5.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration5
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration6.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration6.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 6 parameter(s).
+/// </summary>
+internal static class DiIntegration6
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3, arg4, arg5, arg6 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration6.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration6.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration6
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration7.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration7.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 7 parameter(s).
+/// </summary>
+internal static class DiIntegration7
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration7.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration7.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration7
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration8.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration8.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 8 parameter(s).
+/// </summary>
+internal static class DiIntegration8
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration8.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration8.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration8
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration9.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration9.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// CallTarget integration for methods with 9 parameter(s).
+/// </summary>
+internal static class DiIntegration9
+{
+    internal static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8, TArg9 arg9)
+    {
+        return DiIntegrationHelper.OnMethodBegin(instance, new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
+    }
+
+    internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
+    }
+
+    // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
+    internal static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnMethodEnd(instance, exception, in state);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration9.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegration9.cs
@@ -21,6 +21,13 @@ internal static class DiIntegration9
         return DiIntegrationHelper.OnMethodEnd(instance, returnValue, exception, in state);
     }
 
+    // Async target methods: profiler awaits the Task/ValueTask and calls this with the completed result.
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        return DiIntegrationHelper.OnAsyncMethodEnd(instance, returnValue, exception, in state);
+    }
+
     // Void-returning target methods: profiler requires the non-generic CallTargetReturn.
     internal static CallTargetReturn OnMethodEnd<TTarget>(
         TTarget instance, Exception? exception, in CallTargetState state)

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
@@ -67,22 +67,12 @@ internal static class DiIntegrationHelper
     }
 
     /// <summary>
-    /// Finds the instrumentation key for a registered config whose type name exactly equals <paramref name="targetTypeFullName"/>.
+    /// Finds the instrumentation key for a registered config whose type name exactly equals
+    /// <paramref name="targetTypeFullName"/>, via the registry's indexed lookup (O(1), not a scan).
     /// </summary>
-    // Exact match only: a suffix match would collide across namespaces (e.g. A.Svc vs B.Svc) and pick a nondeterministic winner.
-    internal static string? MatchKeyByType(string targetTypeFullName, InstrumentationRegistry registry)
-    {
-        foreach (var reg in registry.GetAll())
-        {
-            var config = reg.Config;
-            if (targetTypeFullName == config.TypeName)
-            {
-                return config.InstrumentationKey;
-            }
-        }
-
-        return null;
-    }
+    // Exact match only: a suffix match would collide across namespaces (e.g. A.Svc vs B.Svc).
+    internal static string? MatchKeyByType(string targetTypeFullName, InstrumentationRegistry registry) =>
+        registry.TryResolveKeyByType(targetTypeFullName);
 
     internal static StackFrameInfo[] CaptureStackTrace(int maxFrames)
     {
@@ -142,7 +132,7 @@ internal static class DiIntegrationHelper
             return CallTargetState.GetDefault();
         }
 
-        var instrumentationKey = ResolveInstrumentationKey(instance);
+        var instrumentationKey = ResolveInstrumentationKey(instance, args.Length);
         if (instrumentationKey == null)
         {
             return CallTargetState.GetDefault();
@@ -166,18 +156,19 @@ internal static class DiIntegrationHelper
         if (limits.CaptureArguments != null)
         {
             capturedArgs = new Dictionary<string, CapturedValue>();
-            for (int i = 0; i < args.Length; i++)
+
+            // A non-empty CaptureArguments is a positional name filter: capture only the first N args
+            // (N = filter length), naming each from the filter. An empty filter captures every arg,
+            // naming them arg0, arg1, ... . Bounded by args.Length so a filter longer than the
+            // argument list simply captures what exists.
+            var hasNameFilter = limits.CaptureArguments.Length > 0;
+            var count = hasNameFilter
+                ? Math.Min(args.Length, limits.CaptureArguments.Length)
+                : args.Length;
+
+            for (int i = 0; i < count; i++)
             {
-                var name = (limits.CaptureArguments.Length > 0 && i < limits.CaptureArguments.Length)
-                    ? limits.CaptureArguments[i]
-                    : $"arg{i}";
-
-                // Skip args outside a configured named filter.
-                if (limits.CaptureArguments.Length > 0 && i >= limits.CaptureArguments.Length)
-                {
-                    break;
-                }
-
+                var name = hasNameFilter ? limits.CaptureArguments[i] : $"arg{i}";
                 capturedArgs[name] = ValueSerializer.Serialize(args[i], limits);
             }
         }
@@ -210,22 +201,23 @@ internal static class DiIntegrationHelper
             StackTrace = stackTrace,
         };
 
-        DIDataStore.RecordEntry(instrumentationKey, entryData);
+        var callId = DIDataStore.RecordEntry(entryData);
 
-        // Profiler CallTargetState is (Activity, object state); stash the key for OnMethodEnd.
-        return new CallTargetState(activity, instrumentationKey);
+        // Profiler CallTargetState is (Activity, object state); stash the key + per-call id so
+        // OnMethodEnd pairs with THIS invocation's entry (recursion-safe).
+        return new CallTargetState(activity, new CaptureState(instrumentationKey, callId));
     }
 
     // Shared end-of-method capture; hasReturn distinguishes a real (possibly null) return from a void method.
     private static void EndCore<TReturn>(TReturn returnValue, bool hasReturn, Exception? exception, in CallTargetState state)
     {
-        var instrumentationKey = state.State as string;
-        if (instrumentationKey == null)
+        if (state.State is not CaptureState captureState)
         {
             return;
         }
 
-        var entryData = DIDataStore.RetrieveEntry(instrumentationKey);
+        var instrumentationKey = captureState.InstrumentationKey;
+        var entryData = DIDataStore.RetrieveEntry(captureState.CallId);
         if (entryData == null)
         {
             return;
@@ -282,7 +274,11 @@ internal static class DiIntegrationHelper
         DIDataStore.Enqueue(capture);
     }
 
-    private static string? ResolveInstrumentationKey<TTarget>(TTarget instance)
+    // Resolves the config for a woven call. The callback carries no method identity (#3), so we
+    // disambiguate co-located methods by arity (the parameter count, = args.Length). Falls back to a
+    // type-only match when the arity index has no entry yet — e.g. a capture that fires before the
+    // Apply-time IndexArities call, or a registry populated without applying (unit tests).
+    private static string? ResolveInstrumentationKey<TTarget>(TTarget instance, int arity)
     {
         if (registry == null)
         {
@@ -295,7 +291,8 @@ internal static class DiIntegrationHelper
             return null;
         }
 
-        return MatchKeyByType(targetType, registry);
+        return registry.TryResolveKeyByTypeAndArity(targetType, arity)
+            ?? MatchKeyByType(targetType, registry);
     }
 
     private static bool IsInternalFrame(string typeName) =>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
@@ -76,7 +76,9 @@ internal static class DiIntegrationHelper
 
     internal static StackFrameInfo[] CaptureStackTrace(int maxFrames)
     {
-        var trace = new StackTrace(skipFrames: 3, fNeedFileInfo: true);
+        // No skipFrames count: the agent's own frames are dropped by BuildFrames' IsInternalFrame filter,
+        // which is robust where a fixed count would break if the call depth changed.
+        var trace = new StackTrace(fNeedFileInfo: true);
         return BuildFrames(trace, maxFrames);
     }
 

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
@@ -1,0 +1,305 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+
+/// <summary>
+/// Shared entry/exit pairing, context capture, rate limiting, and enqueuing for all DiIntegration0-9 classes.
+/// </summary>
+internal static class DiIntegrationHelper
+{
+    private static volatile InstrumentationRegistry? registry;
+    private static CaptureConfiguration defaultLimits = CaptureConfiguration.Default;
+
+    public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, object?[] args)
+    {
+        // Runs inside the user's woven method: capture must never throw into user code.
+        try
+        {
+            return OnMethodBeginCore(instance, args);
+        }
+        catch
+        {
+            return CallTargetState.GetDefault();
+        }
+    }
+
+    // Non-void methods: profiler weaves OnMethodEnd<TTarget, TReturn> returning CallTargetReturn<TReturn>.
+    public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        // Capture must never throw into user code; return value is always passed through.
+        try
+        {
+            EndCore(returnValue, hasReturn: true, exception, in state);
+        }
+        catch
+        {
+        }
+
+        return new CallTargetReturn<TReturn>(returnValue);
+    }
+
+    // Void methods: profiler resolves the End callback by type identity and requires this non-generic
+    // CallTargetReturn overload; without it void targets are rejected and capture nothing (verified E2E).
+    public static CallTargetReturn OnMethodEnd<TTarget>(
+        TTarget instance, Exception? exception, in CallTargetState state)
+    {
+        try
+        {
+            EndCore<object?>(null, hasReturn: false, exception, in state);
+        }
+        catch
+        {
+        }
+
+        return CallTargetReturn.GetDefault();
+    }
+
+    internal static void Configure(InstrumentationRegistry? registry)
+    {
+        DiIntegrationHelper.registry = registry;
+    }
+
+    /// <summary>
+    /// Finds the instrumentation key for a registered config whose type name exactly equals <paramref name="targetTypeFullName"/>.
+    /// </summary>
+    // Exact match only: a suffix match would collide across namespaces (e.g. A.Svc vs B.Svc) and pick a nondeterministic winner.
+    internal static string? MatchKeyByType(string targetTypeFullName, InstrumentationRegistry registry)
+    {
+        foreach (var reg in registry.GetAll())
+        {
+            var config = reg.Config;
+            if (targetTypeFullName == config.TypeName)
+            {
+                return config.InstrumentationKey;
+            }
+        }
+
+        return null;
+    }
+
+    internal static StackFrameInfo[] CaptureStackTrace(int maxFrames)
+    {
+        var trace = new StackTrace(skipFrames: 3, fNeedFileInfo: true);
+        return BuildFrames(trace, maxFrames);
+    }
+
+    // Uses the exception's own throw-site trace, filtered/capped identically to the entry-time stack.
+    internal static StackFrameInfo[] CaptureExceptionStackTrace(Exception exception, int maxFrames)
+    {
+        var trace = new StackTrace(exception, fNeedFileInfo: true);
+        return BuildFrames(trace, maxFrames);
+    }
+
+    // Filters internal (agent/runtime) frames out of snapshots and caps the frame count.
+    private static StackFrameInfo[] BuildFrames(StackTrace trace, int maxFrames)
+    {
+        var frames = trace.GetFrames();
+        if (frames == null)
+        {
+            return Array.Empty<StackFrameInfo>();
+        }
+
+        var result = new List<StackFrameInfo>();
+        foreach (var frame in frames)
+        {
+            if (result.Count >= maxFrames)
+            {
+                break;
+            }
+
+            var method = frame.GetMethod();
+            if (method == null)
+            {
+                continue;
+            }
+
+            var declaringType = method.DeclaringType?.FullName ?? string.Empty;
+            if (IsInternalFrame(declaringType))
+            {
+                continue;
+            }
+
+            result.Add(new StackFrameInfo(
+                FileName: frame.GetFileName(),
+                MethodName: $"{declaringType}.{method.Name}",
+                LineNumber: frame.GetFileLineNumber()));
+        }
+
+        return result.ToArray();
+    }
+
+    private static CallTargetState OnMethodBeginCore<TTarget>(TTarget instance, object?[] args)
+    {
+        if (registry == null)
+        {
+            return CallTargetState.GetDefault();
+        }
+
+        var instrumentationKey = ResolveInstrumentationKey(instance);
+        if (instrumentationKey == null)
+        {
+            return CallTargetState.GetDefault();
+        }
+
+        if (!registry.TryHit(instrumentationKey))
+        {
+            return CallTargetState.GetDefault();
+        }
+
+        var reg = registry.Get(instrumentationKey);
+        if (reg == null)
+        {
+            return CallTargetState.GetDefault();
+        }
+
+        var config = reg.Config;
+        var limits = config.Capture;
+
+        Dictionary<string, CapturedValue>? capturedArgs = null;
+        if (limits.CaptureArguments != null)
+        {
+            capturedArgs = new Dictionary<string, CapturedValue>();
+            for (int i = 0; i < args.Length; i++)
+            {
+                var name = (limits.CaptureArguments.Length > 0 && i < limits.CaptureArguments.Length)
+                    ? limits.CaptureArguments[i]
+                    : $"arg{i}";
+
+                // Skip args outside a configured named filter.
+                if (limits.CaptureArguments.Length > 0 && i >= limits.CaptureArguments.Length)
+                {
+                    break;
+                }
+
+                capturedArgs[name] = ValueSerializer.Serialize(args[i], limits);
+            }
+        }
+
+        string? traceId = null, spanId = null;
+        var activity = Activity.Current;
+        if (activity != null)
+        {
+            traceId = activity.TraceId.ToHexString();
+            spanId = activity.SpanId.ToHexString();
+        }
+
+        StackFrameInfo[]? stackTrace = null;
+        if (limits.CaptureStackTrace)
+        {
+            stackTrace = CaptureStackTrace(limits.MaxStackFrames);
+        }
+
+        // Stored for pairing with OnMethodEnd.
+        var entryData = new PendingEntryData
+        {
+            InstrumentationKey = instrumentationKey,
+            LocationHash = config.LocationHash,
+            StartTimestamp = Environment.TickCount64,
+            Arguments = capturedArgs,
+            TraceId = traceId,
+            SpanId = spanId,
+            ThreadId = Environment.CurrentManagedThreadId,
+            ThreadName = Thread.CurrentThread.Name ?? $"Thread-{Environment.CurrentManagedThreadId}",
+            StackTrace = stackTrace,
+        };
+
+        DIDataStore.RecordEntry(instrumentationKey, entryData);
+
+        // Profiler CallTargetState is (Activity, object state); stash the key for OnMethodEnd.
+        return new CallTargetState(activity, instrumentationKey);
+    }
+
+    // Shared end-of-method capture; hasReturn distinguishes a real (possibly null) return from a void method.
+    private static void EndCore<TReturn>(TReturn returnValue, bool hasReturn, Exception? exception, in CallTargetState state)
+    {
+        var instrumentationKey = state.State as string;
+        if (instrumentationKey == null)
+        {
+            return;
+        }
+
+        var entryData = DIDataStore.RetrieveEntry(instrumentationKey);
+        if (entryData == null)
+        {
+            return;
+        }
+
+        var reg = registry?.Get(instrumentationKey);
+        var limits = reg?.Config.Capture ?? defaultLimits;
+
+        CapturedValue? capturedReturn = null;
+        if (hasReturn && limits.CaptureReturn)
+        {
+            capturedReturn = ValueSerializer.Serialize(returnValue, limits);
+        }
+
+        // Message truncated to MaxStringLength; exception stack filtered/capped like the entry stack.
+        CapturedValue? capturedException = null;
+        if (exception != null)
+        {
+            var message = exception.Message;
+            var truncated = message.Length > limits.MaxStringLength;
+            if (truncated)
+            {
+                message = message[..limits.MaxStringLength];
+            }
+
+            capturedException = new CapturedValue
+            {
+                Type = exception.GetType().FullName ?? "System.Exception",
+                Value = message,
+                Truncated = truncated,
+                StackFrames = CaptureExceptionStackTrace(exception, limits.MaxStackFrames),
+            };
+        }
+
+        var durationMs = Environment.TickCount64 - entryData.StartTimestamp;
+
+        var capture = new PendingCapture
+        {
+            Type = CaptureType.METHOD,
+            InstrumentationKey = instrumentationKey,
+            LocationHash = entryData.LocationHash,
+            TimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            DurationMs = durationMs,
+            TraceId = entryData.TraceId,
+            SpanId = entryData.SpanId,
+            ThreadId = entryData.ThreadId,
+            ThreadName = entryData.ThreadName,
+            Arguments = entryData.Arguments,
+            ReturnValue = capturedReturn,
+            Exception = capturedException,
+            StackTrace = entryData.StackTrace,
+        };
+
+        DIDataStore.Enqueue(capture);
+    }
+
+    private static string? ResolveInstrumentationKey<TTarget>(TTarget instance)
+    {
+        if (registry == null)
+        {
+            return null;
+        }
+
+        var targetType = typeof(TTarget).FullName;
+        if (targetType == null)
+        {
+            return null;
+        }
+
+        return MatchKeyByType(targetType, registry);
+    }
+
+    private static bool IsInternalFrame(string typeName) =>
+        typeName.StartsWith("AWS.Distro.OpenTelemetry.DynamicInstrumentation") ||
+        typeName.StartsWith("System.Runtime") ||
+        typeName.StartsWith("System.Threading");
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/FunctionLevel/DiIntegrationHelper.cs
@@ -33,6 +33,16 @@ internal static class DiIntegrationHelper
     public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(
         TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
     {
+        // For an awaitable return (Task/Task<T>/ValueTask/ValueTask<T>) the profiler calls this synchronously
+        // with the still-incomplete task, THEN calls OnAsyncMethodEnd once it completes. Serializing the task
+        // here would capture an incomplete result and could block/deadlock the user thread (accessing .Result),
+        // so we defer: leave the paired entry in place and capture in OnAsyncMethodEnd. Mirrors the profiler's
+        // own NoCodeIntegrationHelper.OnMethodEnd, which returns early for the same set of awaitable types.
+        if (IsAwaitableReturn(typeof(TReturn)))
+        {
+            return new CallTargetReturn<TReturn>(returnValue);
+        }
+
         // Capture must never throw into user code; return value is always passed through.
         try
         {
@@ -43,6 +53,25 @@ internal static class DiIntegrationHelper
         }
 
         return new CallTargetReturn<TReturn>(returnValue);
+    }
+
+    // Async non-void methods: the profiler awaits the returned Task/ValueTask and calls this with the
+    // COMPLETED, unwrapped result (returnValue is T for Task<T>/ValueTask<T>; null object for Task/ValueTask).
+    // exception is non-null if the awaited task faulted. This is the profiler's built-in continuation
+    // mechanism (IntegrationMapper.CreateAsyncEndMethodDelegate) — no profiler fork required.
+    public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(
+        TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
+    {
+        // Capture must never throw into user code; the awaited result is always passed through.
+        try
+        {
+            EndCore(returnValue, hasReturn: true, exception, in state);
+        }
+        catch
+        {
+        }
+
+        return returnValue;
     }
 
     // Void methods: profiler resolves the End callback by type identity and requires this non-generic
@@ -295,6 +324,25 @@ internal static class DiIntegrationHelper
 
         return registry.TryResolveKeyByTypeAndArity(targetType, arity)
             ?? MatchKeyByType(targetType, registry);
+    }
+
+    // True when the woven method's return is an awaitable the profiler will continue on (calling
+    // OnAsyncMethodEnd with the completed result), so the synchronous OnMethodEnd must defer. Matches the
+    // set the profiler's EndMethodHandler recognizes: Task, Task<T>, ValueTask, ValueTask<T>.
+    private static bool IsAwaitableReturn(Type returnType)
+    {
+        if (returnType.IsGenericType)
+        {
+            if (typeof(Task).IsAssignableFrom(returnType))
+            {
+                return true; // Task<T>
+            }
+
+            var genericDef = returnType.GetGenericTypeDefinition();
+            return genericDef == typeof(ValueTask<>);
+        }
+
+        return returnType == typeof(Task) || returnType == typeof(ValueTask);
     }
 
     private static bool IsInternalFrame(string typeName) =>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResult.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResult.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+/// <summary>Typed outcome of <see cref="ProfilerTranslator.ApplyInstrumentation"/> that distinguishes a retryable transient failure from a permanent one mapping to a backend InstrumentationErrorCause.</summary>
+internal enum InstrumentationApplyResult
+{
+    /// <summary>At least one definition was registered with the profiler.</summary>
+    Applied,
+
+    /// <summary>Intentionally not applied (line-level or unsupported method); not an error and not reported.</summary>
+    Skipped,
+
+    /// <summary>Target type not found in any loaded assembly (likely not loaded yet); caller should retry on a later poll and must not report an ERROR.</summary>
+    TypeNotLoaded,
+
+    /// <summary>The target type was found but exposes no method with the configured name.</summary>
+    MethodNotFound,
+
+    /// <summary>Method resolved but no overload had a profiler-supported arity (0..9 parameters).</summary>
+    NoSupportedArity,
+
+    /// <summary>The native AddInstrumentations call threw.</summary>
+    RuntimeError,
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResult.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResult.cs
@@ -3,7 +3,7 @@
 
 namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
 
-/// <summary>Typed outcome of <see cref="ProfilerTranslator.ApplyInstrumentation"/> that distinguishes a retryable transient failure from a permanent one mapping to a backend InstrumentationErrorCause.</summary>
+/// <summary>Typed outcome of <see cref="ProfilerTranslator.ApplyInstrumentation(Model.InstrumentationConfiguration)"/> that distinguishes a retryable transient failure from a permanent one mapping to a backend InstrumentationErrorCause.</summary>
 internal enum InstrumentationApplyResult
 {
     /// <summary>At least one definition was registered with the profiler.</summary>

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResult.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResult.cs
@@ -4,9 +4,18 @@
 namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
 
 /// <summary>Typed outcome of <see cref="ProfilerTranslator.ApplyInstrumentation(Model.InstrumentationConfiguration)"/> that distinguishes a retryable transient failure from a permanent one mapping to a backend InstrumentationErrorCause.</summary>
+// This enum is the "instrumentation-failed" taxonomy: whether the SDK could weave the target at all. It is
+// distinct from a "capture-failed" outcome (Capture.NotCapturedReason), which means the method WAS woven and
+// ran but an individual value could not be fully serialized (depth/width/field/timeout limits). The two are
+// reported on different channels: an instrumentation failure is an ERROR status on the configuration (see
+// MapErrorCause); a capture failure is a per-value NotCapturedReason emitted inside the snapshot, never an
+// ERROR on the configuration. Emission of the ERROR status itself lands with StatusReporter in PR3; this
+// enum + MapErrorCause is the taxonomy that PR3 wires to the backend.
 internal enum InstrumentationApplyResult
 {
-    /// <summary>At least one definition was registered with the profiler.</summary>
+    /// <summary>At least one definition was registered with the profiler. Note: a method with mixed arities
+    /// (e.g. overloads at 4 and 12 params) is still Applied for the supported overloads; the over-cap
+    /// overloads are silently skipped — a partial success, not an error.</summary>
     Applied,
 
     /// <summary>Intentionally not applied (line-level or unsupported method); not an error and not reported.</summary>
@@ -15,12 +24,13 @@ internal enum InstrumentationApplyResult
     /// <summary>Target type not found in any loaded assembly (likely not loaded yet); caller should retry on a later poll and must not report an ERROR.</summary>
     TypeNotLoaded,
 
-    /// <summary>The target type was found but exposes no method with the configured name.</summary>
+    /// <summary>The target type was found but exposes no method with the configured name. Permanent (misconfiguration).</summary>
     MethodNotFound,
 
-    /// <summary>Method resolved but no overload had a profiler-supported arity (0..9 parameters).</summary>
+    /// <summary>Method resolved but NO overload had a profiler-supported arity (all exceeded the fixed 9-parameter
+    /// cap — see <see cref="ProfilerTranslator"/>). Permanent for this config until the target is changed.</summary>
     NoSupportedArity,
 
-    /// <summary>The native AddInstrumentations call threw.</summary>
+    /// <summary>The native AddInstrumentations call threw. Permanent (native/profiler error).</summary>
     RuntimeError,
 }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResultExtensions.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationApplyResultExtensions.cs
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+/// <summary>Maps an <see cref="InstrumentationApplyResult"/> to the backend's InstrumentationErrorCause wire
+/// value, and classifies whether a result is a permanent failure worth reporting as an ERROR status.</summary>
+// The instrumentation-failed taxonomy (this type) is deliberately separate from the capture-failed taxonomy
+// (Capture.NotCapturedReason): a value that couldn't be fully serialized is a per-snapshot NotCapturedReason,
+// NOT an ERROR on the configuration. Only weave failures reach here. Emission lands with StatusReporter (PR3).
+internal static class InstrumentationApplyResultExtensions
+{
+    /// <summary>
+    /// True when the result is a permanent instrumentation failure that should be reported to the backend as
+    /// an ERROR exactly once. Applied/Skipped are not failures; TypeNotLoaded is transient (retried, never
+    /// reported — reporting it would spam an ERROR on every poll until the assembly loads).
+    /// </summary>
+    public static bool IsReportableFailure(this InstrumentationApplyResult result) => result switch
+    {
+        InstrumentationApplyResult.MethodNotFound => true,
+        InstrumentationApplyResult.NoSupportedArity => true,
+        InstrumentationApplyResult.RuntimeError => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Maps a result to the backend InstrumentationErrorCause enum value (spec: FILE_NOT_FOUND,
+    /// METHOD_NOT_FOUND, OVERLOADED_METHODS, LANGUAGE_MISMATCH, LINE_NOT_EXECUTABLE, RUNTIME_ERROR).
+    /// Returns null for non-failure results (Applied/Skipped/TypeNotLoaded), which are never reported as ERROR.
+    /// </summary>
+    // NoSupportedArity maps to RUNTIME_ERROR, not a bespoke "arity" cause: the backend enum has no
+    // arity-specific member, and the operator-facing detail (">9 parameters is not supported") belongs in the
+    // human-readable message, not the coarse cause enum. Revisit if the backend adds a dedicated cause.
+    public static string? MapErrorCause(this InstrumentationApplyResult result) => result switch
+    {
+        InstrumentationApplyResult.MethodNotFound => "METHOD_NOT_FOUND",
+        InstrumentationApplyResult.NoSupportedArity => "RUNTIME_ERROR",
+        InstrumentationApplyResult.RuntimeError => "RUNTIME_ERROR",
+        _ => null,
+    };
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationRegistry.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationRegistry.cs
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+/// <summary>
+/// Central registry of active instrumentation configurations and their runtime state.
+/// Thread-safe via ConcurrentDictionary.
+/// </summary>
+internal sealed class InstrumentationRegistry
+{
+    private readonly ConcurrentDictionary<string, RegisteredInstrumentation> configs = new();
+
+    public int Count => this.configs.Count;
+
+    /// <summary>
+    /// Register or update a configuration. Preserves hit state if the config hasn't changed
+    /// (same locationHash + createdAt).
+    /// </summary>
+    public void Register(InstrumentationConfiguration config)
+    {
+        this.configs.AddOrUpdate(
+            config.InstrumentationKey,
+            _ => new RegisteredInstrumentation(config, CreateHitState(config)),
+            (_, existing) =>
+            {
+                if (!HasConfigChanged(existing.Config, config))
+                {
+                    return existing; // Preserve hit state
+                }
+
+                return new RegisteredInstrumentation(config, CreateHitState(config));
+            });
+    }
+
+    /// <summary>
+    /// Remove configurations that are no longer in the active set.
+    /// Returns the keys that were removed.
+    /// </summary>
+    public List<string> RemoveStale(HashSet<string> activeKeys)
+    {
+        var removed = new List<string>();
+        foreach (var key in this.configs.Keys)
+        {
+            if (!activeKeys.Contains(key))
+            {
+                if (this.configs.TryRemove(key, out _))
+                {
+                    removed.Add(key);
+                }
+            }
+        }
+
+        return removed;
+    }
+
+    public RegisteredInstrumentation? Get(string instrumentationKey) =>
+        this.configs.TryGetValue(instrumentationKey, out var reg) ? reg : null;
+
+    public IEnumerable<RegisteredInstrumentation> GetAll() => this.configs.Values;
+
+    public bool TryHit(string instrumentationKey) =>
+        this.configs.TryGetValue(instrumentationKey, out var reg) && reg.HitState.TryHit();
+
+    private static bool HasConfigChanged(InstrumentationConfiguration existing, InstrumentationConfiguration incoming) =>
+        existing.LocationHash != incoming.LocationHash ||
+        existing.CreatedAt != incoming.CreatedAt;
+
+    private static HitState CreateHitState(InstrumentationConfiguration config) =>
+        new(config.Capture.MaxHits, config.ExpiresAt);
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationRegistry.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/InstrumentationRegistry.cs
@@ -14,6 +14,17 @@ internal sealed class InstrumentationRegistry
 {
     private readonly ConcurrentDictionary<string, RegisteredInstrumentation> configs = new();
 
+    // TypeName -> instrumentation keys, so the capture hot path resolves a woven call's config by an
+    // indexed lookup instead of scanning every registered config. A type can host several
+    // instrumented methods, so the value is a set of keys.
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> keysByType = new();
+
+    // (TypeName, arity) -> instrumentation keys. The callback only receives (instance, args), never the
+    // method name/token (#3), so we disambiguate co-located methods by parameter count: args.Length at
+    // capture time. Populated at Apply time (IndexArities) because arity comes from reflecting the loaded
+    // type, not from the config. Same-arity methods on one type still collide — the documented residual.
+    private readonly ConcurrentDictionary<(string Type, int Arity), ConcurrentDictionary<string, byte>> keysByTypeAndArity = new();
+
     public int Count => this.configs.Count;
 
     /// <summary>
@@ -34,6 +45,9 @@ internal sealed class InstrumentationRegistry
 
                 return new RegisteredInstrumentation(config, CreateHitState(config));
             });
+
+        // Keep the TypeName index in sync.
+        this.keysByType.GetOrAdd(config.TypeName, _ => new ConcurrentDictionary<string, byte>())[config.InstrumentationKey] = 0;
     }
 
     /// <summary>
@@ -47,14 +61,88 @@ internal sealed class InstrumentationRegistry
         {
             if (!activeKeys.Contains(key))
             {
-                if (this.configs.TryRemove(key, out _))
+                if (this.configs.TryRemove(key, out var reg))
                 {
                     removed.Add(key);
+                    this.RemoveFromTypeIndex(reg.Config.TypeName, key);
+                    this.RemoveFromArityIndex(reg.Config.TypeName, key);
                 }
             }
         }
 
         return removed;
+    }
+
+    /// <summary>
+    /// Records, at Apply time, that <paramref name="key"/>'s target method exists at the given parameter
+    /// counts on <paramref name="typeName"/>. One config maps to several arities when the method is
+    /// overloaded. Lets the capture hot path disambiguate co-located methods by arity (see #3).
+    /// Returns true if any arity bucket already held a different key — a same-arity collision that arity
+    /// resolution cannot disambiguate (the documented #3 residual), so the caller can report it.
+    /// </summary>
+    public bool IndexArities(string typeName, string key, IReadOnlyCollection<int> arities)
+    {
+        var collided = false;
+        foreach (var arity in arities)
+        {
+            var bucket = this.keysByTypeAndArity.GetOrAdd((typeName, arity), _ => new ConcurrentDictionary<string, byte>());
+
+            // A pre-existing key (other than this one) at the same (type, arity) means two configured
+            // methods are indistinguishable at capture time — args.Length can't separate them.
+            if (bucket.Keys.Any(existing => existing != key))
+            {
+                collided = true;
+            }
+
+            bucket[key] = 0;
+        }
+
+        return collided;
+    }
+
+    /// <summary>
+    /// Resolves the instrumentation key for a woven call by its declaring type name and parameter count.
+    /// Returns null when no config's method on that type has the given arity. When two configured methods
+    /// on one type share both name-slot and arity this still returns one of them — the documented #3
+    /// residual (same-arity collision), which method identity in the callback would be needed to resolve.
+    /// </summary>
+    public string? TryResolveKeyByTypeAndArity(string typeName, int arity)
+    {
+        if (this.keysByTypeAndArity.TryGetValue((typeName, arity), out var keys))
+        {
+            // First key wins; on the capture hot path, so enumerate rather than allocate via .Keys.First().
+            // Same-arity collisions (the documented #3 residual) resolve to one of them nondeterministically.
+            foreach (var key in keys.Keys)
+            {
+                return key;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the instrumentation key for a woven call by its declaring type name alone, when that is
+    /// unambiguous — i.e. exactly one config targets the type. Returns null if no config targets the type,
+    /// OR if two-or-more do (a type-only match would have to guess which, and guessing wrong misattributes
+    /// the capture to the wrong probe — worse than dropping it; see #3).
+    /// </summary>
+    // Type-only fallback for the arity path: used when the arity index has no entry for a call — e.g. a
+    // capture that fires in the window after Register but before the Apply-time IndexArities call, or a
+    // registry populated without applying (unit tests). TryResolveKeyByTypeAndArity is the precise path.
+    public string? TryResolveKeyByType(string typeName)
+    {
+        if (this.keysByType.TryGetValue(typeName, out var keys) && keys.Count == 1)
+        {
+            // Exactly one config for this type → unambiguous. First key wins; enumerate to avoid the
+            // .Keys.First() allocation on the capture hot path.
+            foreach (var key in keys.Keys)
+            {
+                return key;
+            }
+        }
+
+        return null;
     }
 
     public RegisteredInstrumentation? Get(string instrumentationKey) =>
@@ -71,4 +159,36 @@ internal sealed class InstrumentationRegistry
 
     private static HitState CreateHitState(InstrumentationConfiguration config) =>
         new(config.Capture.MaxHits, config.ExpiresAt);
+
+    private void RemoveFromTypeIndex(string typeName, string key)
+    {
+        if (this.keysByType.TryGetValue(typeName, out var keys))
+        {
+            keys.TryRemove(key, out _);
+            if (keys.IsEmpty)
+            {
+                this.keysByType.TryRemove(typeName, out _);
+            }
+        }
+    }
+
+    // The arity index is keyed by (type, arity) and a key can occupy several arity buckets (overloads),
+    // so on removal we sweep every bucket for this type. Serialized with Register/IndexArities by the
+    // Manager's configChangeLock, so enumerating keys here does not race a concurrent writer.
+    private void RemoveFromArityIndex(string typeName, string key)
+    {
+        foreach (var entry in this.keysByTypeAndArity)
+        {
+            if (entry.Key.Type != typeName)
+            {
+                continue;
+            }
+
+            entry.Value.TryRemove(key, out _);
+            if (entry.Value.IsEmpty)
+            {
+                this.keysByTypeAndArity.TryRemove(entry.Key, out _);
+            }
+        }
+    }
 }

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/MethodResolution.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/MethodResolution.cs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+/// <summary>
+/// Result of resolving a target method: the declaring assembly's simple name and the
+/// distinct parameter counts across all overloads sharing the method name.
+/// </summary>
+internal sealed record MethodResolution(string AssemblyName, IReadOnlyCollection<int> Arities);

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/NativeCallTargetDefinition.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/NativeCallTargetDefinition.cs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.InteropServices;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+internal struct NativeCallTargetDefinition : IDisposable
+{
+    [MarshalAs(UnmanagedType.LPWStr)]
+    public string TargetAssembly;
+    [MarshalAs(UnmanagedType.LPWStr)]
+    public string TargetType;
+    [MarshalAs(UnmanagedType.LPWStr)]
+    public string TargetMethod;
+    public IntPtr TargetSignatureTypes;
+    public ushort TargetSignatureTypesLength;
+    public ushort TargetMinimumMajor;
+    public ushort TargetMinimumMinor;
+    public ushort TargetMinimumPatch;
+    public ushort TargetMaximumMajor;
+    public ushort TargetMaximumMinor;
+    public ushort TargetMaximumPatch;
+    [MarshalAs(UnmanagedType.LPWStr)]
+    public string IntegrationAssembly;
+    [MarshalAs(UnmanagedType.LPWStr)]
+    public string IntegrationType;
+
+    public NativeCallTargetDefinition(
+        string targetAssembly,
+        string targetType,
+        string targetMethod,
+        string[] targetSignatureTypes,
+        string integrationAssembly,
+        string integrationType)
+    {
+        this.TargetAssembly = targetAssembly;
+        this.TargetType = targetType;
+        this.TargetMethod = targetMethod;
+        this.TargetMinimumMajor = 0;
+        this.TargetMinimumMinor = 0;
+        this.TargetMinimumPatch = 0;
+        this.TargetMaximumMajor = ushort.MaxValue;
+        this.TargetMaximumMinor = ushort.MaxValue;
+        this.TargetMaximumPatch = ushort.MaxValue;
+        this.IntegrationAssembly = integrationAssembly;
+        this.IntegrationType = integrationType;
+
+        this.TargetSignatureTypesLength = (ushort)targetSignatureTypes.Length;
+        this.TargetSignatureTypes = Marshal.AllocHGlobal(IntPtr.Size * targetSignatureTypes.Length);
+        for (int i = 0; i < targetSignatureTypes.Length; i++)
+        {
+            Marshal.WriteIntPtr(
+                this.TargetSignatureTypes,
+                i * IntPtr.Size,
+                Marshal.StringToHGlobalUni(targetSignatureTypes[i]));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (this.TargetSignatureTypes == IntPtr.Zero)
+        {
+            return;
+        }
+
+        for (int i = 0; i < this.TargetSignatureTypesLength; i++)
+        {
+            var ptr = Marshal.ReadIntPtr(this.TargetSignatureTypes, i * IntPtr.Size);
+            if (ptr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+
+        Marshal.FreeHGlobal(this.TargetSignatureTypes);
+        this.TargetSignatureTypes = IntPtr.Zero;
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/NativeMethods.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/NativeMethods.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.InteropServices;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+internal static class NativeMethods
+{
+    private const string NativeLib = "OpenTelemetry.AutoInstrumentation.Native";
+
+    [DllImport(NativeLib, EntryPoint = "AddInstrumentations")]
+    public static extern void AddInstrumentations(
+        [MarshalAs(UnmanagedType.LPWStr)] string id,
+        [In] NativeCallTargetDefinition[] methodArrays,
+        int size);
+
+    [DllImport(NativeLib, EntryPoint = "AddDerivedInstrumentations")]
+    public static extern void AddDerivedInstrumentations(
+        [MarshalAs(UnmanagedType.LPWStr)] string id,
+        [In] NativeCallTargetDefinition[] methodArrays,
+        int size);
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/ProfilerTranslator.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/ProfilerTranslator.cs
@@ -1,0 +1,171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+/// <summary>
+/// Translates DI configurations into NativeCallTargetDefinitions and registers them with the native profiler via AddInstrumentations P/Invoke.
+/// </summary>
+// The native profiler binds by matching the signature-array length (arity + 1) against the
+// method's parameter count; individual type entries may be the "_" wildcard. So we resolve
+// arity via reflection and register one definition per distinct overload arity.
+internal sealed class ProfilerTranslator
+{
+    private const int MaxSupportedParams = 9;
+    private const string IntegrationAssembly = "AWS.Distro.OpenTelemetry.DynamicInstrumentation";
+    private const string IntegrationTypePrefix = "AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel.DiIntegration";
+
+    private readonly Action<string, NativeCallTargetDefinition[], int>? addInstrumentationsOverride;
+    private readonly Func<InstrumentationConfiguration, MethodResolution?> resolveMethod;
+
+    public ProfilerTranslator(
+        Action<string, NativeCallTargetDefinition[], int>? addInstrumentationsOverride = null,
+        Func<InstrumentationConfiguration, MethodResolution?>? methodResolver = null)
+    {
+        this.addInstrumentationsOverride = addInstrumentationsOverride;
+        this.resolveMethod = methodResolver ?? ReflectionResolveMethod;
+    }
+
+    /// <summary>
+    /// Applies instrumentation for the given config, returning a typed outcome so the caller can distinguish a transient failure (target not yet loaded — retry) from a permanent one (method absent, native throw).
+    /// </summary>
+    /// <param name="config">The configuration to apply.</param>
+    /// <returns>The typed apply outcome.</returns>
+    public InstrumentationApplyResult ApplyInstrumentation(InstrumentationConfiguration config)
+    {
+        if (!config.IsMethodLevel)
+        {
+            return InstrumentationApplyResult.Skipped; // Line-level requires C++ extension (Phase 2)
+        }
+
+        if (IsUnsupportedTarget(config))
+        {
+            return InstrumentationApplyResult.Skipped;
+        }
+
+        var resolution = this.resolveMethod(config);
+        if (resolution == null)
+        {
+            // Type not in any loaded assembly — likely not loaded yet; caller retries and does not report an ERROR.
+            return InstrumentationApplyResult.TypeNotLoaded;
+        }
+
+        if (resolution.Arities.Count == 0)
+        {
+            // Type resolved but has no method by that name — a genuine misconfiguration.
+            return InstrumentationApplyResult.MethodNotFound;
+        }
+
+        var definitions = new List<NativeCallTargetDefinition>();
+        foreach (var arity in resolution.Arities)
+        {
+            if (arity < 0 || arity > MaxSupportedParams)
+            {
+                continue;
+            }
+
+            definitions.Add(new NativeCallTargetDefinition(
+                targetAssembly: resolution.AssemblyName,
+                targetType: config.TypeName,
+                targetMethod: config.MethodName,
+                targetSignatureTypes: BuildSignatureTypes(arity),
+                integrationAssembly: IntegrationAssembly,
+                integrationType: $"{IntegrationTypePrefix}{arity}"));
+        }
+
+        if (definitions.Count == 0)
+        {
+            return InstrumentationApplyResult.NoSupportedArity; // All overloads exceeded MaxSupportedParams
+        }
+
+        var array = definitions.ToArray();
+        try
+        {
+            if (this.addInstrumentationsOverride != null)
+            {
+                this.addInstrumentationsOverride(config.LocationHash, array, array.Length);
+            }
+            else
+            {
+                NativeMethods.AddInstrumentations(config.LocationHash, array, array.Length);
+            }
+
+            return InstrumentationApplyResult.Applied;
+        }
+        catch
+        {
+            return InstrumentationApplyResult.RuntimeError;
+        }
+        finally
+        {
+            foreach (var def in array)
+            {
+                def.Dispose();
+            }
+        }
+    }
+
+    internal static bool IsUnsupportedTarget(InstrumentationConfiguration config)
+    {
+        var method = config.MethodName;
+        return method == ".ctor" || method == ".cctor";
+    }
+
+    /// <summary>
+    /// Resolves the target type's assembly name and the distinct parameter counts (arities) across all overloads of the named method by scanning loaded assemblies; returns null if the type is not found.
+    /// </summary>
+    private static MethodResolution? ReflectionResolveMethod(InstrumentationConfiguration config)
+    {
+        var fullTypeName = config.TypeName;
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type? type;
+            try
+            {
+                type = assembly.GetType(fullTypeName, throwOnError: false);
+            }
+            catch
+            {
+                continue; // Reflection can throw on dynamic/unloadable assemblies
+            }
+
+            if (type == null)
+            {
+                continue;
+            }
+
+            var arities = new HashSet<int>();
+            var methods = type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            foreach (var method in methods)
+            {
+                if (method.Name == config.MethodName)
+                {
+                    arities.Add(method.GetParameters().Length);
+                }
+            }
+
+            // Return even when arities is empty so the caller can distinguish MethodNotFound from a not-yet-loaded type (null).
+            var assemblyName = assembly.GetName().Name ?? config.CodeUnit;
+            return new MethodResolution(assemblyName, arities);
+        }
+
+        return null; // Type not found in any loaded assembly
+    }
+
+    private static string[] BuildSignatureTypes(int paramCount)
+    {
+        // [returnType, param1Type, ...]: profiler matches on array length (paramCount + 1); "_" is the type wildcard, so we never resolve individual parameter type names.
+        var types = new string[paramCount + 1];
+        for (int i = 0; i <= paramCount; i++)
+        {
+            types[i] = "_";
+        }
+
+        return types;
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/ProfilerTranslator.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/ProfilerTranslator.cs
@@ -34,8 +34,22 @@ internal sealed class ProfilerTranslator
     /// </summary>
     /// <param name="config">The configuration to apply.</param>
     /// <returns>The typed apply outcome.</returns>
-    public InstrumentationApplyResult ApplyInstrumentation(InstrumentationConfiguration config)
+    public InstrumentationApplyResult ApplyInstrumentation(InstrumentationConfiguration config) =>
+        this.ApplyInstrumentation(config, out _);
+
+    /// <summary>
+    /// Applies instrumentation and reports the profiler-supported arities that were woven, so the caller
+    /// can index them for arity-aware capture resolution (#3). <paramref name="appliedArities"/> is
+    /// non-empty only when the result is <see cref="InstrumentationApplyResult.Applied"/>.
+    /// </summary>
+    /// <param name="config">The configuration to apply.</param>
+    /// <param name="appliedArities">The parameter counts actually registered with the profiler.</param>
+    /// <returns>The typed apply outcome.</returns>
+    public InstrumentationApplyResult ApplyInstrumentation(
+        InstrumentationConfiguration config, out IReadOnlyCollection<int> appliedArities)
     {
+        appliedArities = Array.Empty<int>();
+
         if (!config.IsMethodLevel)
         {
             return InstrumentationApplyResult.Skipped; // Line-level requires C++ extension (Phase 2)
@@ -59,6 +73,7 @@ internal sealed class ProfilerTranslator
             return InstrumentationApplyResult.MethodNotFound;
         }
 
+        var supportedArities = new List<int>();
         var definitions = new List<NativeCallTargetDefinition>();
         foreach (var arity in resolution.Arities)
         {
@@ -66,6 +81,8 @@ internal sealed class ProfilerTranslator
             {
                 continue;
             }
+
+            supportedArities.Add(arity);
 
             definitions.Add(new NativeCallTargetDefinition(
                 targetAssembly: resolution.AssemblyName,
@@ -93,6 +110,8 @@ internal sealed class ProfilerTranslator
                 NativeMethods.AddInstrumentations(config.LocationHash, array, array.Length);
             }
 
+            // Surface only on success: on a native throw nothing was woven, so nothing should be indexed.
+            appliedArities = supportedArities;
             return InstrumentationApplyResult.Applied;
         }
         catch

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/RegisteredInstrumentation.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Instrumentation/RegisteredInstrumentation.cs
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+internal sealed record RegisteredInstrumentation(InstrumentationConfiguration Config, HitState HitState);

--- a/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Model/InstrumentationConfiguration.cs
+++ b/src/AWS.Distro.OpenTelemetry.DynamicInstrumentation/Model/InstrumentationConfiguration.cs
@@ -75,15 +75,24 @@ public sealed class InstrumentationConfiguration
                 return null;
             }
 
+            // Only explicit "PROBE" selects PROBE; missing/unknown defaults to BREAKPOINT (safer, matches Java/Python/JS).
             var typeStr = element.TryGetProperty("InstrumentationType", out var typeEl)
-                ? typeEl.GetString() : "PROBE";
-            var type = typeStr == "BREAKPOINT" ? InstrumentationType.BREAKPOINT : InstrumentationType.PROBE;
+                ? typeEl.GetString() : null;
+            var type = string.Equals(typeStr, "PROBE", StringComparison.OrdinalIgnoreCase)
+                ? InstrumentationType.PROBE
+                : InstrumentationType.BREAKPOINT;
 
             var codeUnit = location.TryGetProperty(nameof(CodeUnit), out var cuEl) ? cuEl.GetString() ?? string.Empty : string.Empty;
             var className = location.TryGetProperty(nameof(ClassName), out var cnEl) ? cnEl.GetString() ?? string.Empty : string.Empty;
             var methodName = location.TryGetProperty(nameof(MethodName), out var mnEl) ? mnEl.GetString() ?? string.Empty : string.Empty;
             var filePath = location.TryGetProperty(nameof(FilePath), out var fpEl) ? fpEl.GetString() ?? string.Empty : string.Empty;
             var lineNumber = GetIntOrDefault(location, "LineNumber", 0);
+
+            // Required fields: need class+method to bind and a non-negative line; drop malformed configs (CodeUnit may be empty for top-level types).
+            if (string.IsNullOrEmpty(className) || string.IsNullOrEmpty(methodName) || lineNumber < 0)
+            {
+                return null;
+            }
 
             var locationHash = element.TryGetProperty(nameof(LocationHash), out var lhEl)
                 ? lhEl.GetString() ?? string.Empty : string.Empty;
@@ -131,10 +140,8 @@ public sealed class InstrumentationConfiguration
             return CaptureConfiguration.Default;
         }
 
-        if (!ccEl.TryGetProperty("CodeCapture", out var codeCapture))
-        {
-            return CaptureConfiguration.Default;
-        }
+        // Preferred shape wraps fields under "CodeCapture"; legacy backends send them flat, so fall back to the outer element (matches Java/Python/JS).
+        var codeCapture = ccEl.TryGetProperty("CodeCapture", out var wrapped) ? wrapped : ccEl;
 
         string[]? captureArgs = null;
         if (codeCapture.TryGetProperty("CaptureArguments", out var argsEl))
@@ -188,8 +195,7 @@ public sealed class InstrumentationConfiguration
         return new CaptureConfiguration(captureArgs, captureLocals, captureReturn, captureStack, maxStringLength, maxCollectionWidth, maxCollectionDepth, maxObjectDepth, maxFieldsPerObject, maxStackFrames, maxHits);
     }
 
-    // Safe scalar readers: a mistyped field defaults just that field instead of throwing out
-    // of Parse and dropping the whole config. Gate on ValueKind — TryGetInt32 throws on non-numbers.
+    // Safe scalar readers: a mistyped field defaults instead of dropping the whole config. Gate on ValueKind — TryGetInt32 throws on non-numbers.
     private static int GetIntOrDefault(JsonElement obj, string property, int defaultValue)
     {
         if (!obj.TryGetProperty(property, out var el) || el.ValueKind != JsonValueKind.Number)
@@ -217,9 +223,10 @@ public sealed class InstrumentationConfiguration
 
     private static DateTimeOffset? ParseTimestamp(JsonElement el)
     {
-        if (el.ValueKind == JsonValueKind.Number && el.TryGetInt64(out var unixSeconds))
+        // Backend emits epoch seconds as a JSON number, often exponent form (e.g. 1.783975073E9) which TryGetInt64 rejects — read as double; also tolerate the spec's ISO-8601 strings.
+        if (el.ValueKind == JsonValueKind.Number && el.TryGetDouble(out var unixSeconds))
         {
-            return DateTimeOffset.FromUnixTimeSeconds(unixSeconds);
+            return DateTimeOffset.FromUnixTimeSeconds((long)unixSeconds);
         }
 
         if (el.ValueKind == JsonValueKind.String && DateTimeOffset.TryParse(el.GetString(), out var dt))

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.csproj
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.csproj
@@ -34,4 +34,13 @@
     <ProjectReference Include="..\..\src\AWS.Distro.OpenTelemetry.DynamicInstrumentation\AWS.Distro.OpenTelemetry.DynamicInstrumentation.csproj" />
   </ItemGroup>
 
+  <!-- CapturePipelineTests exercises the real profiler CallTargetState type. The DI project
+       references it with Private=false (not copied), so the test project references it here
+       to compile + copy for the test host. -->
+  <ItemGroup>
+    <Reference Include="OpenTelemetry.AutoInstrumentation">
+      <HintPath>..\..\OpenTelemetryDistribution\net\OpenTelemetry.AutoInstrumentation.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/DIDataStoreTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/DIDataStoreTests.cs
@@ -90,6 +90,33 @@ public class DIDataStoreTests : IDisposable
     }
 
     [Fact]
+    public void RecordRetrieve_ProbedParentFansOutToParallelChildren_NoLossOrCorruption()
+    {
+        // Regression: AsyncLocal isolates the slot, not the object. A probed parent sets .Value, then its
+        // entry dictionary flows by reference to every child in a Parallel.ForEach; each child mutating a
+        // plain Dictionary concurrently would drop entries, throw, or hang. A ConcurrentDictionary is safe.
+        var parentId = DIDataStore.RecordEntry(new PendingEntryData { InstrumentationKey = "parent" }); // sets .Value, which flows to children
+
+        const int childCount = 500;
+        var retrieved = new System.Collections.Concurrent.ConcurrentBag<long>();
+
+        var act = () => Parallel.For(0, childCount, new ParallelOptions { MaxDegreeOfParallelism = 16 }, i =>
+        {
+            // Each child does a full Begin/End pair on the SHARED, parent-provided dictionary.
+            var id = DIDataStore.RecordEntry(new PendingEntryData { InstrumentationKey = $"child-{i}" });
+            var entry = DIDataStore.RetrieveEntry(id);
+            if (entry != null)
+            {
+                retrieved.Add(id);
+            }
+        });
+
+        act.Should().NotThrow("concurrent Begin/End on the shared AsyncLocal dictionary must not corrupt it");
+        retrieved.Should().HaveCount(childCount, "every child's entry must be recorded and retrieved without loss");
+        DIDataStore.RetrieveEntry(parentId).Should().NotBeNull("the parent's own entry must survive the children's concurrent mutations");
+    }
+
+    [Fact]
     public void Clear_EmptiesQueueAndEntries()
     {
         DIDataStore.Enqueue(Capture("a"));

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/DIDataStoreTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/DIDataStoreTests.cs
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Capture;
+
+[Collection("SerialProcessState")]
+public class DIDataStoreTests : IDisposable
+{
+    public DIDataStoreTests() => DIDataStore.Clear();
+
+    public void Dispose() => DIDataStore.Clear();
+
+    private static PendingCapture Capture(string key) =>
+        new() { Type = CaptureType.METHOD, InstrumentationKey = key, LocationHash = key };
+
+    [Fact]
+    public void EnqueueThenDrain_ReturnsAllInOrder()
+    {
+        DIDataStore.Enqueue(Capture("a"));
+        DIDataStore.Enqueue(Capture("b"));
+        DIDataStore.Enqueue(Capture("c"));
+
+        var drained = DIDataStore.Drain();
+
+        drained.Select(c => c.InstrumentationKey).Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public void Drain_EmptiesTheQueue()
+    {
+        DIDataStore.Enqueue(Capture("a"));
+
+        DIDataStore.Drain().Should().HaveCount(1);
+        DIDataStore.Drain().Should().BeEmpty(); // second drain is empty
+        DIDataStore.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Count_ReflectsPendingItems()
+    {
+        DIDataStore.Count.Should().Be(0);
+        DIDataStore.Enqueue(Capture("a"));
+        DIDataStore.Enqueue(Capture("b"));
+        DIDataStore.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void RecordThenRetrieveEntry_ReturnsIt()
+    {
+        var entry = new PendingEntryData { InstrumentationKey = "k", LocationHash = "h" };
+        DIDataStore.RecordEntry("k", entry);
+
+        var retrieved = DIDataStore.RetrieveEntry("k");
+
+        retrieved.Should().BeSameAs(entry);
+    }
+
+    [Fact]
+    public void RetrieveEntry_RemovesIt_SecondRetrieveReturnsNull()
+    {
+        DIDataStore.RecordEntry("k", new PendingEntryData { InstrumentationKey = "k" });
+
+        DIDataStore.RetrieveEntry("k").Should().NotBeNull();
+        DIDataStore.RetrieveEntry("k").Should().BeNull(); // consumed
+    }
+
+    [Fact]
+    public void RetrieveEntry_UnknownKey_ReturnsNull()
+    {
+        DIDataStore.RetrieveEntry("never-recorded").Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordEntry_SameKeyTwice_LastWins()
+    {
+        // Models a recursive/re-entrant call on the same instrumentation key: the second
+        // entry overwrites the first (documented behavior of the dictionary-per-context).
+        var first = new PendingEntryData { InstrumentationKey = "k", LocationHash = "first" };
+        var second = new PendingEntryData { InstrumentationKey = "k", LocationHash = "second" };
+        DIDataStore.RecordEntry("k", first);
+        DIDataStore.RecordEntry("k", second);
+
+        DIDataStore.RetrieveEntry("k")!.LocationHash.Should().Be("second");
+    }
+
+    [Fact]
+    public void Clear_EmptiesQueueAndEntries()
+    {
+        DIDataStore.Enqueue(Capture("a"));
+        DIDataStore.RecordEntry("k", new PendingEntryData { InstrumentationKey = "k" });
+
+        DIDataStore.Clear();
+
+        DIDataStore.Count.Should().Be(0);
+        DIDataStore.RetrieveEntry("k").Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Entries_FlowAcrossAsyncBoundary_WithinSameContext()
+    {
+        // AsyncLocal: an entry recorded before an await is visible after it, within the
+        // same logical async flow.
+        DIDataStore.RecordEntry("k", new PendingEntryData { InstrumentationKey = "k", LocationHash = "h" });
+
+        await Task.Yield();
+
+        DIDataStore.RetrieveEntry("k").Should().NotBeNull();
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/DIDataStoreTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/DIDataStoreTests.cs
@@ -50,9 +50,9 @@ public class DIDataStoreTests : IDisposable
     public void RecordThenRetrieveEntry_ReturnsIt()
     {
         var entry = new PendingEntryData { InstrumentationKey = "k", LocationHash = "h" };
-        DIDataStore.RecordEntry("k", entry);
+        var callId = DIDataStore.RecordEntry(entry);
 
-        var retrieved = DIDataStore.RetrieveEntry("k");
+        var retrieved = DIDataStore.RetrieveEntry(callId);
 
         retrieved.Should().BeSameAs(entry);
     }
@@ -60,41 +60,45 @@ public class DIDataStoreTests : IDisposable
     [Fact]
     public void RetrieveEntry_RemovesIt_SecondRetrieveReturnsNull()
     {
-        DIDataStore.RecordEntry("k", new PendingEntryData { InstrumentationKey = "k" });
+        var callId = DIDataStore.RecordEntry(new PendingEntryData { InstrumentationKey = "k" });
 
-        DIDataStore.RetrieveEntry("k").Should().NotBeNull();
-        DIDataStore.RetrieveEntry("k").Should().BeNull(); // consumed
+        DIDataStore.RetrieveEntry(callId).Should().NotBeNull();
+        DIDataStore.RetrieveEntry(callId).Should().BeNull(); // consumed
     }
 
     [Fact]
-    public void RetrieveEntry_UnknownKey_ReturnsNull()
+    public void RetrieveEntry_UnknownCallId_ReturnsNull()
     {
-        DIDataStore.RetrieveEntry("never-recorded").Should().BeNull();
+        DIDataStore.RetrieveEntry(999999).Should().BeNull();
     }
 
     [Fact]
-    public void RecordEntry_SameKeyTwice_LastWins()
+    public void RecordEntry_RecursiveCallsOnSameKey_EachEntrySurvivesIndependently()
     {
-        // Models a recursive/re-entrant call on the same instrumentation key: the second
-        // entry overwrites the first (documented behavior of the dictionary-per-context).
-        var first = new PendingEntryData { InstrumentationKey = "k", LocationHash = "first" };
-        var second = new PendingEntryData { InstrumentationKey = "k", LocationHash = "second" };
-        DIDataStore.RecordEntry("k", first);
-        DIDataStore.RecordEntry("k", second);
+        // Regression: a recursive/re-entrant call on the same instrumentation key used to overwrite
+        // the outer entry (keyed by instrumentation key), so the outer capture was silently dropped.
+        // Per-call ids keep each invocation's entry distinct — inner and outer both pair correctly.
+        var outer = new PendingEntryData { InstrumentationKey = "k", LocationHash = "outer" };
+        var inner = new PendingEntryData { InstrumentationKey = "k", LocationHash = "inner" };
+        var outerId = DIDataStore.RecordEntry(outer);   // outer Begin
+        var innerId = DIDataStore.RecordEntry(inner);   // inner Begin (recursion)
 
-        DIDataStore.RetrieveEntry("k")!.LocationHash.Should().Be("second");
+        // Ends unwind inner-first, then outer — each retrieves its OWN entry, neither is lost.
+        DIDataStore.RetrieveEntry(innerId)!.LocationHash.Should().Be("inner");
+        DIDataStore.RetrieveEntry(outerId)!.LocationHash.Should().Be("outer");
+        outerId.Should().NotBe(innerId);
     }
 
     [Fact]
     public void Clear_EmptiesQueueAndEntries()
     {
         DIDataStore.Enqueue(Capture("a"));
-        DIDataStore.RecordEntry("k", new PendingEntryData { InstrumentationKey = "k" });
+        var callId = DIDataStore.RecordEntry(new PendingEntryData { InstrumentationKey = "k" });
 
         DIDataStore.Clear();
 
         DIDataStore.Count.Should().Be(0);
-        DIDataStore.RetrieveEntry("k").Should().BeNull();
+        DIDataStore.RetrieveEntry(callId).Should().BeNull();
     }
 
     [Fact]
@@ -102,10 +106,10 @@ public class DIDataStoreTests : IDisposable
     {
         // AsyncLocal: an entry recorded before an await is visible after it, within the
         // same logical async flow.
-        DIDataStore.RecordEntry("k", new PendingEntryData { InstrumentationKey = "k", LocationHash = "h" });
+        var callId = DIDataStore.RecordEntry(new PendingEntryData { InstrumentationKey = "k", LocationHash = "h" });
 
         await Task.Yield();
 
-        DIDataStore.RetrieveEntry("k").Should().NotBeNull();
+        DIDataStore.RetrieveEntry(callId).Should().NotBeNull();
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/ValueSerializerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/ValueSerializerTests.cs
@@ -101,6 +101,30 @@ public class ValueSerializerTests
     }
 
     [Fact]
+    public void Serialize_LazyEnumerable_StopsAtMaxWidth()
+    {
+        // A non-ICollection lazy sequence must NOT be walked in full (it may be infinite and this
+        // runs on the user's thread). We enumerate at most MaxCollectionWidth+1: width captured, +1 to
+        // detect truncation.
+        int pulled = 0;
+        IEnumerable<int> Lazy()
+        {
+            while (true)
+            {
+                pulled++;
+                yield return pulled;
+            }
+        }
+
+        var result = ValueSerializer.Serialize(Lazy(), DefaultLimits);
+
+        result.Elements.Should().HaveCount(20); // MaxCollectionWidth = 20
+        result.NotCapturedReason.Should().Be(NotCapturedReason.CollectionSize);
+        result.OriginalSize.Should().Be(21, "unknown-size sequences report at-least width+1, not an exact walked count");
+        pulled.Should().Be(21, "the infinite sequence must be pulled only width+1 times, never fully enumerated");
+    }
+
+    [Fact]
     public void Serialize_Dictionary_ReturnsFields()
     {
         var dict = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/ValueSerializerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/ValueSerializerTests.cs
@@ -101,27 +101,95 @@ public class ValueSerializerTests
     }
 
     [Fact]
-    public void Serialize_LazyEnumerable_StopsAtMaxWidth()
+    public void Serialize_HashSet_WalkedAsCollection_NotReflectedAsObject()
     {
-        // A non-ICollection lazy sequence must NOT be walked in full (it may be infinite and this
-        // runs on the user's thread). We enumerate at most MaxCollectionWidth+1: width captured, +1 to
-        // detect truncation.
-        int pulled = 0;
+        // Regression: HashSet<T> implements only the generic ICollection<T>, NOT the non-generic
+        // System.Collections.ICollection. A dispatch that checked only non-generic ICollection would
+        // fall through to the object serializer and capture Count/Comparer instead of the elements —
+        // yet the set's size IS O(1), so it must be walked. This pins that sets are captured as collections.
+        var set = new HashSet<int> { 10, 20, 30 };
+
+        var result = ValueSerializer.Serialize(set, DefaultLimits);
+
+        result.Elements.Should().NotBeNull("a HashSet has an O(1) count and must be walked as a collection");
+        result.Elements.Should().HaveCount(3);
+        result.Elements!.Select(e => e.Value).Should().BeEquivalentTo("10", "20", "30");
+        result.Fields.Should().BeNull("it must not be reflected as an object (Count/Comparer fields)");
+    }
+
+    [Fact]
+    public void Serialize_LargeHashSet_TruncatesToMaxWidth_ReportsTrueSize()
+    {
+        // A set larger than MaxCollectionWidth caps at the width and reports the real total from the
+        // O(1) generic count — never a pulled-item lower bound.
+        var set = new HashSet<int>(Enumerable.Range(1, 50));
+
+        var result = ValueSerializer.Serialize(set, DefaultLimits);
+
+        result.Elements.Should().HaveCount(20); // MaxCollectionWidth = 20
+        result.OriginalSize.Should().Be(50);
+        result.NotCapturedReason.Should().Be(NotCapturedReason.CollectionSize);
+    }
+
+    [Fact]
+    public void Serialize_Queue_WalkedAsCollection()
+    {
+        // Queue<T>/Stack<T> implement the non-generic ICollection — the other O(1)-count path.
+        var queue = new Queue<string>(new[] { "a", "b" });
+
+        var result = ValueSerializer.Serialize(queue, DefaultLimits);
+
+        result.Elements.Should().HaveCount(2);
+        result.Fields.Should().BeNull();
+    }
+
+    [Fact]
+    public void Serialize_CollectionWithThrowingCount_DoesNotAbortCapture_SerializedAsObject()
+    {
+        // A user collection whose generic Count getter throws (lazy/remote-backed, disposed view, thread
+        // affinity) must NOT propagate out of Serialize — that would escape the whole invocation's capture.
+        // It falls through to the object serializer instead.
+        var obj = new ThrowingCountCollection();
+
+        var act = () => ValueSerializer.Serialize(obj, DefaultLimits);
+
+        act.Should().NotThrow("a throwing Count getter must not abort capture");
+        var result = act();
+        result.Elements.Should().BeNull("it must not be walked as a collection when its count is unavailable");
+    }
+
+    [Fact]
+    public void Serialize_CollectionMutatedMidEnumeration_KeepsPartialCapture()
+    {
+        // Enumeration runs on the user's thread. If the collection is mutated mid-walk the enumerator throws;
+        // the partial capture must stand rather than aborting the whole invocation.
+        var mutating = new MutatingOnEnumerate();
+
+        var act = () => ValueSerializer.Serialize(mutating, DefaultLimits);
+
+        act.Should().NotThrow("a mid-enumeration mutation must not abort capture");
+        var result = act();
+        result.Elements.Should().NotBeNull("elements captured before the mutation must survive");
+    }
+
+    [Fact]
+    public void Serialize_CountlessEnumerable_NotWalked_SerializedAsObject()
+    {
+        // A countless/lazy IEnumerable (no O(1) size) must NOT be treated as a collection: walking it could
+        // be unbounded/infinite on the user's thread, and any pulled count would be a fake size. It falls
+        // through to the object serializer instead (matches Java/Python). This generator throws if pulled.
+        var pulled = false;
         IEnumerable<int> Lazy()
         {
-            while (true)
-            {
-                pulled++;
-                yield return pulled;
-            }
+            pulled = true;
+            yield return 1;
         }
 
         var result = ValueSerializer.Serialize(Lazy(), DefaultLimits);
 
-        result.Elements.Should().HaveCount(20); // MaxCollectionWidth = 20
-        result.NotCapturedReason.Should().Be(NotCapturedReason.CollectionSize);
-        result.OriginalSize.Should().Be(21, "unknown-size sequences report at-least width+1, not an exact walked count");
-        pulled.Should().Be(21, "the infinite sequence must be pulled only width+1 times, never fully enumerated");
+        pulled.Should().BeFalse("a countless IEnumerable must not be enumerated as a collection");
+        result.Elements.Should().BeNull("it is serialized as an object, not a collection");
+        result.NotCapturedReason.Should().Be(NotCapturedReason.None);
     }
 
     [Fact]
@@ -379,5 +447,63 @@ public class ValueSerializerTests
     private class ThrowingProp
     {
         public string Bad => throw new InvalidOperationException("no access");
+    }
+
+    // Implements only the generic ICollection<T> (so the non-generic ICollection fast path is skipped and
+    // the reflected generic Count getter runs) and throws from Count — simulates a lazy/remote-backed count.
+    private class ThrowingCountCollection : ICollection<int>
+    {
+        public int Count => throw new InvalidOperationException("count unavailable");
+
+        public bool IsReadOnly => true;
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            yield return 1;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        public void Add(int item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(int item) => throw new NotSupportedException();
+
+        public void CopyTo(int[] array, int arrayIndex) => throw new NotSupportedException();
+
+        public bool Remove(int item) => throw new NotSupportedException();
+    }
+
+    // A walkable collection (real O(1) Count) whose enumerator mutates its own backing store mid-iteration,
+    // forcing the "collection was modified" InvalidOperationException on the user's thread.
+    private class MutatingOnEnumerate : ICollection<int>
+    {
+        private readonly List<int> backing = new() { 1, 2, 3, 4, 5 };
+
+        public int Count => this.backing.Count;
+
+        public bool IsReadOnly => true;
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            foreach (var item in this.backing)
+            {
+                yield return item;
+                this.backing.Add(item); // mutate mid-walk → List<T> enumerator throws on the next MoveNext
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        public void Add(int item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(int item) => throw new NotSupportedException();
+
+        public void CopyTo(int[] array, int arrayIndex) => throw new NotSupportedException();
+
+        public bool Remove(int item) => throw new NotSupportedException();
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/ValueSerializerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Capture/ValueSerializerTests.cs
@@ -1,0 +1,359 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Capture;
+
+public class ValueSerializerTests
+{
+    private static readonly CaptureConfiguration DefaultLimits = CaptureConfiguration.Default;
+
+    [Fact]
+    public void Serialize_Null_ReturnsNullType()
+    {
+        var result = ValueSerializer.Serialize(null, DefaultLimits);
+
+        result.Type.Should().Be("null");
+        result.Value.Should().Be("null");
+    }
+
+    [Fact]
+    public void Serialize_Int_ReturnsPrimitive()
+    {
+        var result = ValueSerializer.Serialize(42, DefaultLimits);
+
+        result.Type.Should().Be("System.Int32");
+        result.Value.Should().Be("42");
+    }
+
+    [Fact]
+    public void Serialize_Bool_ReturnsPrimitive()
+    {
+        var result = ValueSerializer.Serialize(true, DefaultLimits);
+
+        result.Type.Should().Be("System.Boolean");
+        result.Value.Should().Be("True");
+    }
+
+    [Fact]
+    public void Serialize_Double_ReturnsPrimitive()
+    {
+        var result = ValueSerializer.Serialize(3.14, DefaultLimits);
+
+        result.Type.Should().Be("System.Double");
+        result.Value.Should().Be("3.14");
+    }
+
+    [Fact]
+    public void Serialize_ShortString_ReturnsFullValue()
+    {
+        var result = ValueSerializer.Serialize("hello", DefaultLimits);
+
+        result.Type.Should().Be("System.String");
+        result.Value.Should().Be("hello");
+        result.Truncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Serialize_LongString_Truncates()
+    {
+        var longStr = new string('x', 500);
+        var result = ValueSerializer.Serialize(longStr, DefaultLimits);
+
+        result.Value!.Length.Should().Be(255);
+        result.Truncated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Serialize_CustomMaxStringLength_Respected()
+    {
+        var limits = DefaultLimits with { MaxStringLength = 10 };
+        var result = ValueSerializer.Serialize("hello world, this is long", limits);
+
+        result.Value!.Length.Should().Be(10);
+        result.Truncated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Serialize_List_ReturnsElements()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var result = ValueSerializer.Serialize(list, DefaultLimits);
+
+        result.Elements.Should().HaveCount(3);
+        result.Elements![0].Value.Should().Be("1");
+        result.Elements[1].Value.Should().Be("2");
+        result.Elements[2].Value.Should().Be("3");
+        result.OriginalSize.Should().BeNull(); // not truncated
+    }
+
+    [Fact]
+    public void Serialize_LargeList_TruncatesToMaxWidth()
+    {
+        var list = Enumerable.Range(1, 50).ToList();
+        var result = ValueSerializer.Serialize(list, DefaultLimits);
+
+        result.Elements.Should().HaveCount(20); // MaxCollectionWidth = 20
+        result.OriginalSize.Should().Be(50);
+        result.NotCapturedReason.Should().Be(NotCapturedReason.CollectionSize);
+    }
+
+    [Fact]
+    public void Serialize_Dictionary_ReturnsFields()
+    {
+        var dict = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var result = ValueSerializer.Serialize(dict, DefaultLimits);
+
+        result.Fields.Should().ContainKey("a");
+        result.Fields.Should().ContainKey("b");
+        result.Fields!["a"].Value.Should().Be("1");
+    }
+
+    [Fact]
+    public void Serialize_LargeDictionary_TruncatesToMaxWidth()
+    {
+        var dict = Enumerable.Range(1, 50).ToDictionary(i => $"key{i}", i => i);
+        var result = ValueSerializer.Serialize(dict, DefaultLimits);
+
+        result.Fields.Should().HaveCount(20);
+        result.OriginalSize.Should().Be(50);
+        result.NotCapturedReason.Should().Be(NotCapturedReason.CollectionSize);
+    }
+
+    [Fact]
+    public void Serialize_Object_CapturesPublicFieldsAndProperties()
+    {
+        var obj = new TestObj { Name = "Alice", Age = 30 };
+        var result = ValueSerializer.Serialize(obj, DefaultLimits);
+
+        result.Type.Should().Contain("TestObj");
+        result.Fields.Should().ContainKey("Name");
+        result.Fields.Should().ContainKey("Age");
+        result.Fields!["Name"].Value.Should().Be("Alice");
+        result.Fields!["Age"].Value.Should().Be("30");
+    }
+
+    [Fact]
+    public void Serialize_DepthLimit_StopsRecursion()
+    {
+        var limits = DefaultLimits with { MaxObjectDepth = 1 };
+        var obj = new Nested { Inner = new Nested { Inner = new Nested() } };
+
+        var result = ValueSerializer.Serialize(obj, limits);
+
+        result.Fields.Should().ContainKey("Inner");
+        result.Fields!["Inner"].Value.Should().Contain("depth limit");
+        result.Fields!["Inner"].NotCapturedReason.Should().Be(NotCapturedReason.Depth);
+    }
+
+    [Fact]
+    public void Serialize_MaxFieldsPerObject_Respected()
+    {
+        var limits = DefaultLimits with { MaxFieldsPerObject = 1 };
+        var obj = new TestObj { Name = "Alice", Age = 30 };
+
+        var result = ValueSerializer.Serialize(obj, limits);
+
+        result.Fields.Should().HaveCount(1);
+        result.NotCapturedReason.Should().Be(NotCapturedReason.FieldCount);
+    }
+
+    [Fact]
+    public void Serialize_Array_ReturnsElements()
+    {
+        var arr = new[] { "a", "b", "c" };
+        var result = ValueSerializer.Serialize(arr, DefaultLimits);
+
+        result.Elements.Should().HaveCount(3);
+        result.Elements![0].Value.Should().Be("a");
+    }
+
+    [Fact]
+    public void Serialize_Enum_ReturnsPrimitive()
+    {
+        var result = ValueSerializer.Serialize(DayOfWeek.Monday, DefaultLimits);
+
+        result.Type.Should().Be("System.DayOfWeek");
+        result.Value.Should().Be("Monday");
+    }
+
+    [Fact]
+    public void Serialize_SelfReferencingObject_TerminatesViaDepthLimit()
+    {
+        // Production hazard: a cyclic object graph must not StackOverflow. The depth
+        // limit must bound the recursion.
+        var a = new Nested();
+        a.Inner = a; // direct self-cycle
+
+        var act = () => ValueSerializer.Serialize(a, DefaultLimits with { MaxObjectDepth = 3 });
+
+        act.Should().NotThrow();
+        var result = act();
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Serialize_MutualCycle_Terminates()
+    {
+        var a = new Nested();
+        var b = new Nested();
+        a.Inner = b;
+        b.Inner = a; // A <-> B cycle
+
+        var act = () => ValueSerializer.Serialize(a, DefaultLimits with { MaxObjectDepth = 5 });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Serialize_DirectSelfCycle_ReportsAlreadyCaptured()
+    {
+        // Reference-cycle detection fires on identity before the depth cap: a's Inner is a itself,
+        // so the nested reference is marked AlreadyCaptured rather than recursed into.
+        var a = new Nested();
+        a.Inner = a;
+
+        var result = ValueSerializer.Serialize(a, DefaultLimits with { MaxObjectDepth = 5 });
+
+        result.Fields!["Inner"].NotCapturedReason.Should().Be(NotCapturedReason.AlreadyCaptured);
+        result.Fields!["Inner"].Fields.Should().BeNull("the cycle is cut, not recursed");
+    }
+
+    [Fact]
+    public void Serialize_SameObjectAsSiblings_NotFalsePositivedAsCycle()
+    {
+        // The same object referenced twice as SIBLINGS (not ancestry) must be captured both times —
+        // the visited set removes the reference on unwind so siblings aren't flagged as cycles.
+        var shared = new Nested();
+        var parent = new HasTwo { First = shared, Second = shared };
+
+        var result = ValueSerializer.Serialize(parent, DefaultLimits with { MaxObjectDepth = 5 });
+
+        result.Fields!["First"].NotCapturedReason.Should().Be(NotCapturedReason.None);
+        result.Fields!["Second"].NotCapturedReason.Should().Be(NotCapturedReason.None);
+    }
+
+    [Fact]
+    public void Serialize_NullElementsInCollection_HandledGracefully()
+    {
+        var list = new List<string?> { "a", null, "c" };
+
+        var result = ValueSerializer.Serialize(list, DefaultLimits);
+
+        result.Elements.Should().HaveCount(3);
+        result.Elements![1].Type.Should().Be("null");
+    }
+
+    [Fact]
+    public void Serialize_NullValuesInDictionary_HandledGracefully()
+    {
+        var dict = new Dictionary<string, string?> { ["present"] = "v", ["missing"] = null };
+
+        var result = ValueSerializer.Serialize(dict, DefaultLimits);
+
+        result.Fields!["missing"].Type.Should().Be("null");
+    }
+
+    [Fact]
+    public void Serialize_PropertyThatThrows_CapturesAccessErrorNotCrash()
+    {
+        var obj = new ThrowingProp();
+
+        var act = () => ValueSerializer.Serialize(obj, DefaultLimits);
+
+        act.Should().NotThrow();
+        var result = act();
+        result.Fields.Should().ContainKey(nameof(ThrowingProp.Bad));
+        result.Fields![nameof(ThrowingProp.Bad)].Value.Should().Contain("access error");
+    }
+
+    [Fact]
+    public void Serialize_EmptyCollection_ReturnsEmptyElements()
+    {
+        var result = ValueSerializer.Serialize(new List<int>(), DefaultLimits);
+
+        result.Elements.Should().NotBeNull();
+        result.Elements.Should().BeEmpty();
+        result.OriginalSize.Should().BeNull();
+    }
+
+    [Fact]
+    public void Serialize_NestedCollection_RespectsDepth()
+    {
+        // A list of lists must not recurse unbounded.
+        var inner = new List<object> { 1, 2 };
+        var outer = new List<object> { inner, inner };
+
+        var act = () => ValueSerializer.Serialize(outer, DefaultLimits with { MaxObjectDepth = 2 });
+
+        act.Should().NotThrow();
+        act().Elements.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Serialize_MaxCollectionDepth_BoundsNestedCollections()
+    {
+        // Regression: MaxCollectionDepth used to be parsed/clamped/stored but never read —
+        // collection nesting was silently bounded by MaxObjectDepth instead. This proves the
+        // knob is authoritative: a deeply nested list is cut at MaxCollectionDepth regardless
+        // of a generous MaxObjectDepth.
+        var depth4 = new List<object> { new List<object> { new List<object> { new List<object> { 1 } } } };
+        var limits = DefaultLimits with { MaxCollectionDepth = 2, MaxObjectDepth = 5 };
+
+        var result = ValueSerializer.Serialize(depth4, limits);
+
+        // depth 0 (outer) -> depth 1 (inner) -> depth 2 hits the limit, rendered as marker.
+        var level1 = result.Elements!.Single();
+        var level2 = level1.Elements!.Single();
+        level2.Value.Should().Contain("depth limit");
+        level2.Elements.Should().BeNull();
+    }
+
+    [Fact]
+    public void Serialize_SelfReferencingCollection_TerminatesViaCollectionDepth()
+    {
+        // A collection that contains itself must terminate on MaxCollectionDepth, not
+        // StackOverflow.
+        var list = new List<object>();
+        list.Add(list);
+
+        var act = () => ValueSerializer.Serialize(list, DefaultLimits with { MaxCollectionDepth = 3 });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Serialize_TruncationBoundary_ExactlyMaxLength_NotTruncated()
+    {
+        var exact = new string('y', 255);
+        var result = ValueSerializer.Serialize(exact, DefaultLimits);
+
+        result.Truncated.Should().BeFalse();
+        result.Value!.Length.Should().Be(255);
+    }
+
+    private class TestObj
+    {
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+    }
+
+    private class Nested
+    {
+        public Nested? Inner { get; set; }
+    }
+
+    private class HasTwo
+    {
+        public Nested? First { get; set; }
+
+        public Nested? Second { get; set; }
+    }
+
+    private class ThrowingProp
+    {
+        public string Bad => throw new InvalidOperationException("no access");
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/ConfigurationPollerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/ConfigurationPollerTests.cs
@@ -115,7 +115,7 @@ public class ConfigurationPollerTests
         var client = ClientReturning(
             ChangedResponse(ProbeConfig("aabb000000000001")),
             ChangedResponse(ProbeConfig("aabb000000000001")));
-        var poller = CreatePoller(client, invocations.Add);
+        var poller = CreatePoller(client, c => { invocations.Add(c); return true; });
 
         (await InvokeFetchAndApply(poller, InstrumentationType.PROBE)).Should().BeTrue();
         (await InvokeFetchAndApply(poller, InstrumentationType.PROBE)).Should().BeTrue();
@@ -133,7 +133,7 @@ public class ConfigurationPollerTests
         var client = ClientReturning(
             ChangedResponse(ProbeConfig("hashKeep"), ProbeConfig("hashRemove")),
             ChangedResponse(ProbeConfig("hashKeep")));
-        var poller = CreatePoller(client, invocations.Add);
+        var poller = CreatePoller(client, c => { invocations.Add(c); return true; });
 
         await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
         await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
@@ -157,6 +157,9 @@ public class ConfigurationPollerTests
         {
             invocationCount++;
             throw new InvalidOperationException("apply failed");
+#pragma warning disable CS0162 // Unreachable — satisfies the Func<..., bool> signature; the throw exits first.
+            return true;
+#pragma warning restore CS0162
         });
 
         // First poll: the callback runs and throws — the exception propagates out of FetchAndApply.
@@ -173,6 +176,41 @@ public class ConfigurationPollerTests
         invocationCount.Should().Be(2, "a thrown apply leaves the fingerprint stale, so the next poll retries");
     }
 
+    [Fact]
+    public async Task FetchAndApply_CallbackReturnsFalse_DoesNotPersistFingerprint_SoNextPollRetries()
+    {
+        // A false result means "not fully applied" (e.g. a target's assembly isn't loaded yet). The
+        // fingerprint must stay stale so an identical next poll re-invokes and retries.
+        var invocationCount = 0;
+        var client = ClientReturning(
+            ChangedResponse(ProbeConfig("aabb0000000000aa")),
+            ChangedResponse(ProbeConfig("aabb0000000000aa")));
+        var poller = CreatePoller(client, _ => { invocationCount++; return false; });
+
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+        GetLastFingerprint(poller).Should().BeEmpty("a false (not-fully-applied) result must not latch the fingerprint");
+
+        // Second identical poll: fingerprint still stale → the callback fires again (retry).
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+        invocationCount.Should().Be(2, "an unapplied target must be retried on the next poll despite an unchanged config");
+    }
+
+    [Fact]
+    public async Task FetchAndApply_CallbackReturnsTrue_PersistsFingerprint_SoIdenticalPollSkips()
+    {
+        // A true (fully-applied) result latches the fingerprint, so an identical next poll is skipped.
+        var invocationCount = 0;
+        var client = ClientReturning(
+            ChangedResponse(ProbeConfig("aabb0000000000bb")),
+            ChangedResponse(ProbeConfig("aabb0000000000bb")));
+        var poller = CreatePoller(client, _ => { invocationCount++; return true; });
+
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+
+        invocationCount.Should().Be(1, "a fully-applied set latches the fingerprint, so an identical poll skips");
+    }
+
     [Fact(Skip = "parity: needs staleness-warning / forced-resync — not yet implemented (source has only a TODO at ConfigurationPoller.cs:43)")]
     public void StalenessWarning_ForcesFullResync_WhenNoSuccessWithinWindow()
     {
@@ -184,7 +222,7 @@ public class ConfigurationPollerTests
     // --- Fingerprint-path helpers ---
 
     private static ConfigurationPoller CreatePoller(
-        DynamicInstrumentationClient client, Action<List<InstrumentationConfiguration>> onChanged) =>
+        DynamicInstrumentationClient client, Func<List<InstrumentationConfiguration>, bool> onChanged) =>
         new(client, probeIntervalSeconds: 60, breakpointIntervalSeconds: 60, onChanged, CancellationToken.None);
 
     private static DynamicInstrumentationClient ClientReturning(params string[] responseBodies)

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/ConfigurationPollerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/ConfigurationPollerTests.cs
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Net;
+using System.Reflection;
+using System.Text;
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Client;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
 
 namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Client;
 
@@ -97,4 +101,125 @@ public class ConfigurationPollerTests
         observed[2].Should().Be(120_000); // the tier the off-by-one used to skip
         observed[3].Should().BeInRange(300_000, 375_000); // degraded
     }
+
+    // --- Config-change fingerprint path ---
+    // These drive the private FetchAndApply loop directly (via reflection) so the change-detection
+    // fingerprint logic can be exercised deterministically without spinning up the polling threads.
+
+    [Fact]
+    public async Task FetchAndApply_IdenticalConfigsOnSecondPoll_SkipsRetransform()
+    {
+        // Same config returned twice with Changed=true. The fingerprint (LocationHash:CreatedAt)
+        // SetEquals the previous one, so the callback must NOT fire again — no re-transform.
+        var invocations = new List<List<InstrumentationConfiguration>>();
+        var client = ClientReturning(
+            ChangedResponse(ProbeConfig("aabb000000000001")),
+            ChangedResponse(ProbeConfig("aabb000000000001")));
+        var poller = CreatePoller(client, invocations.Add);
+
+        (await InvokeFetchAndApply(poller, InstrumentationType.PROBE)).Should().BeTrue();
+        (await InvokeFetchAndApply(poller, InstrumentationType.PROBE)).Should().BeTrue();
+
+        invocations.Should().HaveCount(1, "an identical fingerprint must not re-invoke the apply callback");
+        invocations[0].Should().ContainSingle().Which.LocationHash.Should().Be("aabb000000000001");
+    }
+
+    [Fact]
+    public async Task FetchAndApply_RemovedKeyOnSecondPoll_TriggersRemoval()
+    {
+        // Two configs, then one removed. The fingerprint changes, so the callback fires again
+        // with the reduced active set (the removed key is gone).
+        var invocations = new List<List<InstrumentationConfiguration>>();
+        var client = ClientReturning(
+            ChangedResponse(ProbeConfig("hashKeep"), ProbeConfig("hashRemove")),
+            ChangedResponse(ProbeConfig("hashKeep")));
+        var poller = CreatePoller(client, invocations.Add);
+
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+
+        invocations.Should().HaveCount(2, "removing a key changes the fingerprint and must re-apply");
+        invocations[0].Select(c => c.LocationHash).Should().BeEquivalentTo("hashKeep", "hashRemove");
+        invocations[1].Select(c => c.LocationHash).Should().BeEquivalentTo(new[] { "hashKeep" });
+    }
+
+    [Fact]
+    public async Task FetchAndApply_ApplyThrows_DoesNotPersistFingerprint_SoNextPollRetries()
+    {
+        // Fixed behavior (parity with Java/Python/JS): lastFingerprint is persisted only AFTER the
+        // apply callback succeeds. When the callback throws, the fingerprint stays stale, so an
+        // identical next poll does NOT SetEquals it and the apply is RETRIED.
+        var invocationCount = 0;
+        var client = ClientReturning(
+            ChangedResponse(ProbeConfig("aabb000000000099")),
+            ChangedResponse(ProbeConfig("aabb000000000099")));
+        var poller = CreatePoller(client, _ =>
+        {
+            invocationCount++;
+            throw new InvalidOperationException("apply failed");
+        });
+
+        // First poll: the callback runs and throws — the exception propagates out of FetchAndApply.
+        var act = async () => await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("apply failed");
+
+        // The fingerprint was NOT persisted because the callback threw.
+        GetLastFingerprint(poller).Should().BeEmpty("fingerprint is persisted only after a successful apply");
+
+        // Second identical poll: fingerprint is still stale, so the apply is retried.
+        var act2 = async () => await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+        await act2.Should().ThrowAsync<InvalidOperationException>().WithMessage("apply failed");
+
+        invocationCount.Should().Be(2, "a thrown apply leaves the fingerprint stale, so the next poll retries");
+    }
+
+    [Fact(Skip = "parity: needs staleness-warning / forced-resync — not yet implemented (source has only a TODO at ConfigurationPoller.cs:43)")]
+    public void StalenessWarning_ForcesFullResync_WhenNoSuccessWithinWindow()
+    {
+        // Intended: when no successful sync occurs within the staleness window (30m probes / 5m
+        // breakpoints), the poller should clear SyncedAt and force a full resync (and/or warn).
+        // No such logic exists in ConfigurationPoller today, so this is a tracked placeholder.
+    }
+
+    // --- Fingerprint-path helpers ---
+
+    private static ConfigurationPoller CreatePoller(
+        DynamicInstrumentationClient client, Action<List<InstrumentationConfiguration>> onChanged) =>
+        new(client, probeIntervalSeconds: 60, breakpointIntervalSeconds: 60, onChanged, CancellationToken.None);
+
+    private static DynamicInstrumentationClient ClientReturning(params string[] responseBodies)
+    {
+        var queue = new Queue<string>(responseBodies);
+        var handler = new MockHttpHandler(_ =>
+        {
+            var body = queue.Count > 0 ? queue.Dequeue() : """{ "Changed": false }""";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+        });
+        return new DynamicInstrumentationClient(new HttpClient(handler), "http://localhost:2000", "test-service", "test-env");
+    }
+
+    private static Task<bool> InvokeFetchAndApply(ConfigurationPoller poller, InstrumentationType type)
+    {
+        var method = typeof(ConfigurationPoller).GetMethod(
+            "FetchAndApply", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Task<bool>)method.Invoke(poller, new object[] { type })!;
+    }
+
+    private static HashSet<string> GetLastFingerprint(ConfigurationPoller poller)
+    {
+        var field = typeof(ConfigurationPoller).GetField(
+            "lastFingerprint", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (HashSet<string>)field.GetValue(poller)!;
+    }
+
+    private static string ProbeConfig(string locationHash) =>
+        "{ \"InstrumentationType\": \"PROBE\", \"LocationHash\": \"" + locationHash + "\", " +
+        "\"Location\": { \"CodeLocation\": { \"Language\": \"Dotnet\", \"ClassName\": \"OrderService\", \"MethodName\": \"Process\" } } }";
+
+    private static string ChangedResponse(params string[] configs) =>
+        "{ \"Changed\": true, \"SyncedAt\": \"2024-09-17T22:03:24Z\", \"LatestConfigurations\": [" +
+        string.Join(",", configs) + "] }";
 }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/ConfigurationPollerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/ConfigurationPollerTests.cs
@@ -211,6 +211,32 @@ public class ConfigurationPollerTests
         invocationCount.Should().Be(1, "a fully-applied set latches the fingerprint, so an identical poll skips");
     }
 
+    [Fact]
+    public async Task FetchAndApply_ApplyNeedsRetry_DoesNotAdvanceCursor_SoBackendKeepsReturningChanged()
+    {
+        // A Changed=true fetch whose apply returns false (target not loaded yet) must NOT advance the sync
+        // cursor. Advancing it would make the next poll return Changed=false and short-circuit before
+        // apply, so the retry would never run and the probe would stay dead.
+        var client = ClientReturning(ChangedResponse(ProbeConfig("aabb0000000000cc")));
+        var poller = CreatePoller(client, _ => false);
+
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+
+        ProbeCursorAdvanced(poller).Should().BeFalse("an unapplied set must leave the cursor stale so the next poll re-fetches Changed=true");
+    }
+
+    [Fact]
+    public async Task FetchAndApply_ApplySucceeds_AdvancesCursor()
+    {
+        // Complement: a fully-applied set advances the cursor (normal forward progress).
+        var client = ClientReturning(ChangedResponse(ProbeConfig("aabb0000000000dd")));
+        var poller = CreatePoller(client, _ => true);
+
+        await InvokeFetchAndApply(poller, InstrumentationType.PROBE);
+
+        ProbeCursorAdvanced(poller).Should().BeTrue("a fully-applied set advances the cursor");
+    }
+
     [Fact(Skip = "parity: needs staleness-warning / forced-resync — not yet implemented (source has only a TODO at ConfigurationPoller.cs:43)")]
     public void StalenessWarning_ForcesFullResync_WhenNoSuccessWithinWindow()
     {
@@ -251,6 +277,13 @@ public class ConfigurationPollerTests
         var field = typeof(ConfigurationPoller).GetField(
             "lastFingerprint", BindingFlags.NonPublic | BindingFlags.Instance)!;
         return (HashSet<string>)field.GetValue(poller)!;
+    }
+
+    private static bool ProbeCursorAdvanced(ConfigurationPoller poller)
+    {
+        var field = typeof(ConfigurationPoller).GetField(
+            "probeSyncedAt", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return field.GetValue(poller) != null;
     }
 
     private static string ProbeConfig(string locationHash) =>

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/DynamicInstrumentationClientTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/DynamicInstrumentationClientTests.cs
@@ -142,6 +142,58 @@ public class DynamicInstrumentationClientTests
     }
 
     [Fact]
+    public async Task FetchConfigurations_404OnLaterPage_AbandonsFetch_DoesNotReturnPartialSet()
+    {
+        // Page 0 returns configs + a NextToken; page 1 then 404s. A 404 mid-pagination is a transient
+        // paging failure, NOT a removal. Returning the partial page-0 set as a complete Changed=true result
+        // would make the caller diff it and tear down every not-yet-fetched live probe. The client must
+        // abandon the whole fetch (Success=false) so the caller keeps its current cache.
+        int callCount = 0;
+        var handler = new MockHttpHandler(_ =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""
+                    {
+                        "Changed": true,
+                        "SyncedAt": "2024-09-17T22:03:24Z",
+                        "NextToken": "page2",
+                        "LatestConfigurations": [{ "LocationHash": "config1" }]
+                    }
+                    """, Encoding.UTF8, "application/json"),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.FetchConfigurationsAsync(InstrumentationType.PROBE);
+
+        callCount.Should().Be(2, "it should attempt page 2 and hit the 404");
+        result.Success.Should().BeFalse("a mid-pagination 404 abandons the whole fetch");
+        result.Configurations.Should().BeEmpty("the partial page-0 set must not surface as a complete result");
+    }
+
+    [Fact]
+    public async Task FetchConfigurations_404OnFirstPage_IsEmptyUnchanged_NotFailure()
+    {
+        // A 404 on page 0 is the normal "no configs for this service/env" case — an empty, unchanged
+        // (Changed=false) success, not a failure and not a removal.
+        var handler = new MockHttpHandler(HttpStatusCode.NotFound, string.Empty);
+        var client = CreateClient(handler);
+
+        var result = await client.FetchConfigurationsAsync(InstrumentationType.PROBE);
+
+        result.Success.Should().BeTrue();
+        result.Changed.Should().BeFalse();
+        result.Configurations.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task FetchConfigurations_LatchesChangedFromFirstPage_NoDataLoss()
     {
         // Regression: `changed` was reassigned every page. A continuation page with

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/DynamicInstrumentationClientTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/DynamicInstrumentationClientTests.cs
@@ -247,10 +247,13 @@ public class DynamicInstrumentationClientTests
     [Fact]
     public async Task FetchConfigurations_SendsCorrectRequestBody()
     {
-        HttpContent? capturedContent = null;
+        // Read the request body inside the handler, while the content is live — the client disposes the
+        // HttpRequestMessage (and its Content) once the exchange completes, so reading req.Content after
+        // the call returns would hit a disposed object.
+        string? capturedBody = null;
         var handler = new MockHttpHandler(req =>
         {
-            capturedContent = req.Content;
+            capturedBody = new StreamReader(req.Content!.ReadAsStream()).ReadToEnd();
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("""{ "Changed": false }""", Encoding.UTF8, "application/json")
@@ -261,9 +264,8 @@ public class DynamicInstrumentationClientTests
         await client.FetchConfigurationsAsync(
             InstrumentationType.BREAKPOINT, syncedAt: Json("\"2024-09-17T22:03:24Z\""));
 
-        capturedContent.Should().NotBeNull();
-        var capturedBody = await capturedContent!.ReadAsStringAsync();
-        var doc = JsonDocument.Parse(capturedBody);
+        capturedBody.Should().NotBeNull();
+        var doc = JsonDocument.Parse(capturedBody!);
         // Request fields must be PascalCase to match the API (and the Java/Python/Node SDKs).
         // A case-sensitive backend treats camelCase as missing → empty/unfiltered configs.
         doc.RootElement.GetProperty("Service").GetString().Should().Be("test-service");
@@ -279,10 +281,11 @@ public class DynamicInstrumentationClientTests
         // The round-trip that broke against the live backend: a numeric SyncedAt received from
         // the server must be echoed back on the next request AS A NUMBER, not a quoted string,
         // or the backend rejects the cursor. Guards the JsonElement round-trip end to end.
-        HttpContent? capturedContent = null;
+        // Capture the body during the request; the client disposes the request message on return.
+        string? capturedBody = null;
         var handler = new MockHttpHandler(req =>
         {
-            capturedContent = req.Content;
+            capturedBody = new StreamReader(req.Content!.ReadAsStream()).ReadToEnd();
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("""{ "Changed": false }""", Encoding.UTF8, "application/json"),
@@ -293,8 +296,8 @@ public class DynamicInstrumentationClientTests
         await client.FetchConfigurationsAsync(
             InstrumentationType.PROBE, syncedAt: Json("1.7839751E9"));
 
-        var capturedBody = await capturedContent!.ReadAsStringAsync();
-        var doc = JsonDocument.Parse(capturedBody);
+        capturedBody.Should().NotBeNull();
+        var doc = JsonDocument.Parse(capturedBody!);
         doc.RootElement.GetProperty("SyncedAt").ValueKind.Should().Be(JsonValueKind.Number);
         doc.RootElement.GetProperty("SyncedAt").GetRawText().Should().Be("1.7839751E9");
     }
@@ -302,10 +305,11 @@ public class DynamicInstrumentationClientTests
     [Fact]
     public async Task ReportStatus_SendsRequest()
     {
-        HttpContent? capturedContent = null;
+        // Capture the body during the request; the client disposes the request message on return.
+        string? capturedBody = null;
         var handler = new MockHttpHandler(req =>
         {
-            capturedContent = req.Content;
+            capturedBody = new StreamReader(req.Content!.ReadAsStream()).ReadToEnd();
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
 
@@ -315,8 +319,7 @@ public class DynamicInstrumentationClientTests
             new() { LocationHash = "hash1", Status = "READY", InstrumentationType = "PROBE" }
         });
 
-        capturedContent.Should().NotBeNull();
-        var capturedBody = await capturedContent!.ReadAsStringAsync();
+        capturedBody.Should().NotBeNull();
         capturedBody.Should().Contain("hash1");
         capturedBody.Should().Contain("READY");
     }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/DynamicInstrumentationClientTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Client/DynamicInstrumentationClientTests.cs
@@ -14,6 +14,10 @@ public class DynamicInstrumentationClientTests
     private static DynamicInstrumentationClient CreateClient(MockHttpHandler handler) =>
         new(new HttpClient(handler), "http://localhost:2000", "test-service", "test-env");
 
+    // Parses a JSON literal (e.g. "\"abc\"" or "123") into a standalone JsonElement, mirroring how
+    // the client captures the opaque SyncedAt cursor from a response for echo-back.
+    private static JsonElement Json(string literal) => JsonDocument.Parse(literal).RootElement.Clone();
+
     [Fact]
     public async Task FetchConfigurations_ReturnsConfigs_OnSuccess()
     {
@@ -39,7 +43,7 @@ public class DynamicInstrumentationClientTests
 
         result.Success.Should().BeTrue();
         result.Changed.Should().BeTrue();
-        result.SyncedAt.Should().Be("2024-09-17T22:03:24Z");
+        result.SyncedAt!.Value.GetString().Should().Be("2024-09-17T22:03:24Z");
         result.SyncInterval.Should().Be(60);
         result.Configurations.Should().HaveCount(1);
     }
@@ -47,20 +51,39 @@ public class DynamicInstrumentationClientTests
     [Fact]
     public async Task FetchConfigurations_ParsesIso8601SyncedAt_WithoutFailing()
     {
-        // Regression: the spec types SyncedAt as an ISO-8601 string. Modeling it as long?
-        // made System.Text.Json throw on every real response, so every poll returned
-        // Failed and the client never synced. This proves the string wire value parses.
+        // The API spec types SyncedAt as an ISO-8601 string. SyncedAt is a JsonElement so it
+        // round-trips either wire shape; here the string form must parse without failing.
         var responseJson = """{ "Changed": false, "SyncedAt": "2024-09-17T22:08:24Z" }""";
 
         var handler = new MockHttpHandler(HttpStatusCode.OK, responseJson);
         var client = CreateClient(handler);
 
         var result = await client.FetchConfigurationsAsync(
-            InstrumentationType.PROBE, syncedAt: "2024-09-17T22:03:24Z");
+            InstrumentationType.PROBE, syncedAt: Json("\"2024-09-17T22:03:24Z\""));
 
         result.Success.Should().BeTrue();
         result.Changed.Should().BeFalse();
-        result.SyncedAt.Should().Be("2024-09-17T22:08:24Z");
+        result.SyncedAt!.Value.GetString().Should().Be("2024-09-17T22:08:24Z");
+    }
+
+    [Fact]
+    public async Task FetchConfigurations_ParsesNumericSyncedAt_FromLiveBackend()
+    {
+        // Verified against the live backend (application-signals.us-east-1.api.aws): it emits
+        // SyncedAt as a JSON NUMBER in exponent form, NOT the ISO string the spec documents.
+        // Modeling SyncedAt as string? made System.Text.Json throw here, so every poll returned
+        // Failed and the client silently never synced. This pins the real wire shape.
+        var responseJson = """{ "Changed": true, "SyncInterval": 300, "SyncedAt": 1.7839751E9, "LatestConfigurations": [] }""";
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, responseJson);
+        var client = CreateClient(handler);
+
+        var result = await client.FetchConfigurationsAsync(InstrumentationType.PROBE);
+
+        result.Success.Should().BeTrue("the live backend returns a numeric SyncedAt and the client must parse it");
+        result.Changed.Should().BeTrue();
+        result.SyncedAt!.Value.ValueKind.Should().Be(JsonValueKind.Number);
+        result.SyncedAt!.Value.GetRawText().Should().Be("1.7839751E9");
     }
 
     [Fact]
@@ -72,7 +95,7 @@ public class DynamicInstrumentationClientTests
         var client = CreateClient(handler);
 
         var result = await client.FetchConfigurationsAsync(
-            InstrumentationType.BREAKPOINT, syncedAt: "2024-09-17T22:03:24Z");
+            InstrumentationType.BREAKPOINT, syncedAt: Json("\"2024-09-17T22:03:24Z\""));
 
         result.Changed.Should().BeFalse();
         result.Configurations.Should().BeEmpty();
@@ -236,7 +259,7 @@ public class DynamicInstrumentationClientTests
 
         var client = CreateClient(handler);
         await client.FetchConfigurationsAsync(
-            InstrumentationType.BREAKPOINT, syncedAt: "2024-09-17T22:03:24Z");
+            InstrumentationType.BREAKPOINT, syncedAt: Json("\"2024-09-17T22:03:24Z\""));
 
         capturedContent.Should().NotBeNull();
         var capturedBody = await capturedContent!.ReadAsStringAsync();
@@ -246,8 +269,34 @@ public class DynamicInstrumentationClientTests
         doc.RootElement.GetProperty("Service").GetString().Should().Be("test-service");
         doc.RootElement.GetProperty("Environment").GetString().Should().Be("test-env");
         doc.RootElement.GetProperty("InstrumentationType").GetString().Should().Be("BREAKPOINT");
-        // SyncedAt must serialize as an ISO-8601 string on the wire (spec contract).
+        // SyncedAt echoes back verbatim in the shape it was received (here a string).
         doc.RootElement.GetProperty("SyncedAt").GetString().Should().Be("2024-09-17T22:03:24Z");
+    }
+
+    [Fact]
+    public async Task FetchConfigurations_EchoesNumericSyncedAt_BackAsNumber()
+    {
+        // The round-trip that broke against the live backend: a numeric SyncedAt received from
+        // the server must be echoed back on the next request AS A NUMBER, not a quoted string,
+        // or the backend rejects the cursor. Guards the JsonElement round-trip end to end.
+        HttpContent? capturedContent = null;
+        var handler = new MockHttpHandler(req =>
+        {
+            capturedContent = req.Content;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{ "Changed": false }""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var client = CreateClient(handler);
+        await client.FetchConfigurationsAsync(
+            InstrumentationType.PROBE, syncedAt: Json("1.7839751E9"));
+
+        var capturedBody = await capturedContent!.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(capturedBody);
+        doc.RootElement.GetProperty("SyncedAt").ValueKind.Should().Be(JsonValueKind.Number);
+        doc.RootElement.GetProperty("SyncedAt").GetRawText().Should().Be("1.7839751E9");
     }
 
     [Fact]

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Config/DynamicInstrumentationConfigTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Config/DynamicInstrumentationConfigTests.cs
@@ -43,7 +43,7 @@ public class DynamicInstrumentationConfigTests : IDisposable
         SetEnv("OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", "http://myagent:3000");
         SetEnv("OTEL_AWS_DYNAMIC_INSTRUMENTATION_PROBE_POLL_INTERVAL", "300");
         SetEnv("OTEL_AWS_DYNAMIC_INSTRUMENTATION_BREAKPOINT_POLL_INTERVAL", "30");
-        SetEnv("OTEL_AWS_DYNAMIC_INSTRUMENTATION_LOGS_ENDPOINT", "http://collector:4317/v1/logs");
+        SetEnv("OTEL_AWS_OTLP_LOGS_ENDPOINT", "http://collector:4317/v1/logs");
 
         var config = DynamicInstrumentationConfig.FromEnvironment();
 

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/DynamicInstrumentationManagerTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/DynamicInstrumentationManagerTests.cs
@@ -3,12 +3,18 @@
 
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation;
 using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Config;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
 
 namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests;
 
 [Collection("SerialProcessState")]
-public class DynamicInstrumentationManagerTests
+public class DynamicInstrumentationManagerTests : IDisposable
 {
+    // The Manager singleton owns a background snapshot collector that drains the process-global
+    // DIDataStore. Shut it down after every test so its drain thread is joined and stops competing
+    // with other global-state suites for the shared queue.
+    public void Dispose() => DynamicInstrumentationManager.Instance.Shutdown();
+
     private static DynamicInstrumentationConfig CreateConfig(bool enabled = true) =>
         new(
             Enabled: enabled,
@@ -89,5 +95,203 @@ public class DynamicInstrumentationManagerTests
         // Calling shutdown when not initialized should not throw
         var act = () => manager.Shutdown();
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void OnConfigurationsChanged_RegistersAndApplies()
+    {
+        var manager = DynamicInstrumentationManager.Instance;
+        manager.Shutdown();
+        manager.Initialize(CreateConfig());
+
+        var configs = new List<InstrumentationConfiguration>
+        {
+            new()
+            {
+                Type = InstrumentationType.PROBE,
+                CodeUnit = "MyApp",
+                ClassName = "OrderService",
+                MethodName = "Process",
+                LocationHash = "hash1",
+                Capture = CaptureConfiguration.Default
+            }
+        };
+
+        manager.OnConfigurationsChanged(configs);
+
+        manager.Registry.Should().NotBeNull();
+        manager.Registry!.Count.Should().Be(1);
+        manager.Registry.Get("MyApp.OrderService.Process").Should().NotBeNull();
+
+        manager.Shutdown();
+    }
+
+    [Fact]
+    public void OnConfigurationsChanged_SkipsUnsupportedTargets()
+    {
+        var manager = DynamicInstrumentationManager.Instance;
+        manager.Shutdown();
+        manager.Initialize(CreateConfig());
+
+        var configs = new List<InstrumentationConfiguration>
+        {
+            new()
+            {
+                Type = InstrumentationType.PROBE,
+                CodeUnit = "MyApp",
+                ClassName = "OrderService",
+                MethodName = ".ctor",
+                LocationHash = "hash1",
+                Capture = CaptureConfiguration.Default
+            }
+        };
+
+        manager.OnConfigurationsChanged(configs);
+
+        manager.Registry!.Count.Should().Be(0);
+
+        manager.Shutdown();
+    }
+
+    [Fact]
+    public void OnConfigurationsChanged_RemovesStaleConfigs()
+    {
+        var manager = DynamicInstrumentationManager.Instance;
+        manager.Shutdown();
+        manager.Initialize(CreateConfig());
+
+        var configs = new List<InstrumentationConfiguration>
+        {
+            new()
+            {
+                Type = InstrumentationType.PROBE,
+                CodeUnit = "MyApp",
+                ClassName = "Svc",
+                MethodName = "A",
+                LocationHash = "h1",
+                Capture = CaptureConfiguration.Default
+            },
+            new()
+            {
+                Type = InstrumentationType.PROBE,
+                CodeUnit = "MyApp",
+                ClassName = "Svc",
+                MethodName = "B",
+                LocationHash = "h2",
+                Capture = CaptureConfiguration.Default
+            }
+        };
+
+        manager.OnConfigurationsChanged(configs);
+        manager.Registry!.Count.Should().Be(2);
+
+        // Second call with only method A — B should be removed
+        manager.OnConfigurationsChanged(new List<InstrumentationConfiguration> { configs[0] });
+        manager.Registry.Count.Should().Be(1);
+        manager.Registry.Get("MyApp.Svc.B").Should().BeNull();
+
+        manager.Shutdown();
+    }
+
+    [Fact]
+    public void OnConfigurationsChanged_ConcurrentCallers_DoNotCorruptState()
+    {
+        // The poller invokes OnConfigurationsChanged from BOTH the probe and breakpoint threads.
+        // appliedInstrumentations is a plain HashSet; without the configChangeLock guard, two
+        // threads mutating it concurrently either throw (torn HashSet) or leave the registry and
+        // applied-set diverged. This test reproduces the two-thread contention and asserts the
+        // final state is consistent — each caller repeatedly delivers its OWN full set, so the
+        // last write from either thread must leave exactly that thread's configs registered.
+        var manager = DynamicInstrumentationManager.Instance;
+        manager.Shutdown();
+        manager.Initialize(CreateConfig());
+
+        static InstrumentationConfiguration Make(string cls, string method, string hash) =>
+            new()
+            {
+                Type = InstrumentationType.PROBE,
+                CodeUnit = "MyApp",
+                ClassName = cls,
+                MethodName = method,
+                LocationHash = hash,
+                Capture = CaptureConfiguration.Default,
+            };
+
+        // Two disjoint config sets, one per thread. Sets are large so the shared applied-set
+        // repeatedly grows/shrinks (and resizes) as the two threads churn each other's keys via
+        // RemoveStale — resize under concurrent mutation is where a plain HashSet corrupts/throws.
+        var setA = Enumerable.Range(0, 40).Select(i => Make("SvcA", $"A{i}", $"a{i}")).ToList();
+        var setB = Enumerable.Range(0, 40).Select(i => Make("SvcB", $"B{i}", $"b{i}")).ToList();
+
+        Exception? failure = null;
+        void Hammer(List<InstrumentationConfiguration> set)
+        {
+            try
+            {
+                for (int i = 0; i < 2000; i++)
+                {
+                    manager.OnConfigurationsChanged(set);
+                }
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        }
+
+        var t1 = new Thread(() => Hammer(setA));
+        var t2 = new Thread(() => Hammer(setB));
+        t1.Start();
+        t2.Start();
+        t1.Join();
+        t2.Join();
+
+        failure.Should().BeNull("concurrent OnConfigurationsChanged must not throw on the shared applied-set");
+
+        // Whichever thread wrote last, the registry must hold exactly that thread's set (40 configs) —
+        // never a torn mix or a diverged count. RemoveStale drops the other thread's keys.
+        manager.Registry!.Count.Should().Be(40);
+
+        manager.Shutdown();
+    }
+
+    [Fact]
+    public void ShutdownThenReinitialize_ReRegistersConfigs()
+    {
+        // Regression for C3: the applied-instrumentations set must be cleared on
+        // Cleanup, otherwise after a restart OnConfigurationsChanged would register the
+        // config into the fresh registry but skip re-applying it (stale "already applied"
+        // key), leaving registry and applied-set diverged.
+        var manager = DynamicInstrumentationManager.Instance;
+        manager.Shutdown();
+        manager.Initialize(CreateConfig());
+
+        var config = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = "MyApp",
+            ClassName = "OrderService",
+            MethodName = "Process",
+            LocationHash = "hash1",
+            Capture = CaptureConfiguration.Default
+        };
+        var configs = new List<InstrumentationConfiguration> { config };
+
+        manager.OnConfigurationsChanged(configs);
+        manager.Registry!.Count.Should().Be(1);
+
+        // Restart
+        manager.Shutdown();
+        manager.Initialize(CreateConfig());
+
+        // Fresh registry must be empty until reconfigured
+        manager.Registry!.Count.Should().Be(0);
+
+        // Re-delivering the same config must register it again (not silently skipped)
+        manager.OnConfigurationsChanged(configs);
+        manager.Registry.Count.Should().Be(1);
+        manager.Registry.Get("MyApp.OrderService.Process").Should().NotBeNull();
+
+        manager.Shutdown();
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/CapturePipelineTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/CapturePipelineTests.cs
@@ -1,0 +1,243 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Capture;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+using OpenTelemetry.AutoInstrumentation.CallTarget;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation;
+
+// End-to-end test of the capture pipeline: OnMethodBegin -> DIDataStore -> OnMethodEnd
+// -> drain. Exercises DiIntegrationHelper against a real InstrumentationRegistry with no
+// profiler. Static state (_registry, DIDataStore queue/AsyncLocal) is mutated, so these
+// run serially and clear state per test.
+[Collection("SerialProcessState")]
+public class CapturePipelineTests : IDisposable
+{
+    // The target type: its FullName must equal CodeUnit + "." + ClassName so
+    // ResolveInstrumentationKey<TTarget> matches the registered config.
+    // Namespace here is the test namespace; class is CaptureTarget.
+    private const string CodeUnit = "AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation";
+    private const string ClassName = "CaptureTarget";
+
+    public CapturePipelineTests() => DIDataStore.Clear();
+
+    public void Dispose() => DIDataStore.Clear();
+
+    private static InstrumentationRegistry RegistryWith(CaptureConfiguration capture, string method = "Process")
+    {
+        var registry = new InstrumentationRegistry();
+        registry.Register(new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = CodeUnit,
+            ClassName = ClassName,
+            MethodName = method,
+            LocationHash = "loc-hash-1",
+            Capture = capture
+        });
+        DiIntegrationHelper.Configure(registry);
+        return registry;
+    }
+
+    [Fact]
+    public void FullCycle_CapturesArguments_ReturnValue_Duration()
+    {
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "ORD-1", 5 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "result", null, in state);
+
+        var drained = DIDataStore.Drain();
+        drained.Should().HaveCount(1);
+        var cap = drained[0];
+        cap.Type.Should().Be(CaptureType.METHOD);
+        cap.LocationHash.Should().Be("loc-hash-1");
+        cap.Arguments.Should().NotBeNull();
+        cap.Arguments!["arg0"].Value.Should().Be("ORD-1");
+        cap.Arguments["arg1"].Value.Should().Be("5");
+        cap.ReturnValue.Should().NotBeNull();
+        cap.ReturnValue!.Value.Should().Be("result");
+        cap.Exception.Should().BeNull();
+        cap.DurationMs.Should().BeGreaterThanOrEqualTo(0);
+        cap.ThreadId.Should().Be(Environment.CurrentManagedThreadId);
+    }
+
+    [Fact]
+    public void FullCycle_CapturesException()
+    {
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+        var ex = new InvalidOperationException("boom");
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, null!, ex, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.Exception.Should().NotBeNull();
+        cap.Exception!.Type.Should().Be("System.InvalidOperationException");
+        cap.Exception.Value.Should().Be("boom");
+
+        // Exception stack is now stored as structured frames (not a raw string). This exception was
+        // never thrown, so its frame list may be empty — the filtering guarantee is asserted in
+        // FullCycle_Exception_TruncatesMessage_AndCapsFrames, which throws for real.
+        cap.Exception.StackFrames.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FullCycle_Exception_TruncatesMessage_AndCapsFrames()
+    {
+        var capture = CaptureConfiguration.Default with { MaxStringLength = 10, MaxStackFrames = 2 };
+        RegistryWith(capture);
+        var target = new CaptureTarget();
+
+        // Build a genuinely-thrown exception so it has a real (deep) stack trace to filter+cap.
+        Exception ex;
+        try
+        {
+            throw new InvalidOperationException(new string('x', 500));
+        }
+        catch (Exception caught)
+        {
+            ex = caught;
+        }
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, null!, ex, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.Exception!.Value.Should().HaveLength(10, "message is truncated to MaxStringLength");
+        cap.Exception.Truncated.Should().BeTrue();
+        cap.Exception.StackFrames.Should().NotBeNull();
+        cap.Exception.StackFrames!.Length.Should().BeLessThanOrEqualTo(2, "frames capped at MaxStackFrames");
+
+        // Whatever frames survive have all passed the internal-frame filter shared with the entry
+        // stack (BuildFrames) — none are agent/runtime-internal frames.
+        cap.Exception.StackFrames.Should()
+            .NotContain(f => f.MethodName!.StartsWith("AWS.Distro.OpenTelemetry.DynamicInstrumentation")
+                          || f.MethodName.StartsWith("System.Runtime")
+                          || f.MethodName.StartsWith("System.Threading"));
+    }
+
+    [Fact]
+    public void NamedArguments_CaptureOnlyNamedSubset()
+    {
+        var capture = CaptureConfiguration.Default with { CaptureArguments = new[] { "orderId", "quantity" } };
+        RegistryWith(capture);
+        var target = new CaptureTarget();
+
+        // Three args passed, but only two named — third must be dropped.
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "ORD", 5, "extra" });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "r", null, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.Arguments!.Keys.Should().BeEquivalentTo(new[] { "orderId", "quantity" });
+        cap.Arguments["orderId"].Value.Should().Be("ORD");
+        cap.Arguments["quantity"].Value.Should().Be("5");
+    }
+
+    [Fact]
+    public void CaptureReturnFalse_OmitsReturnValue()
+    {
+        var capture = CaptureConfiguration.Default with { CaptureReturn = false };
+        RegistryWith(capture);
+        var target = new CaptureTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "secret", null, in state);
+
+        DIDataStore.Drain().Single().ReturnValue.Should().BeNull();
+    }
+
+    [Fact]
+    public void UnregisteredType_DoesNotCapture()
+    {
+        RegistryWith(CaptureConfiguration.Default);
+        var stranger = new UnrelatedTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<UnrelatedTarget>(stranger, new object?[] { 1 });
+        DiIntegrationHelper.OnMethodEnd<UnrelatedTarget, int>(stranger, 0, null, in state);
+
+        DIDataStore.Drain().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MaxHitsExceeded_StopsCapturing()
+    {
+        var capture = new CaptureConfiguration(
+            CaptureArguments: Array.Empty<string>(), CaptureLocals: null,
+            CaptureReturn: true, CaptureStackTrace: false,
+            MaxStringLength: 255, MaxCollectionWidth: 20, MaxCollectionDepth: 3,
+            MaxObjectDepth: 3, MaxFieldsPerObject: 20, MaxStackFrames: 20, MaxHits: 2);
+        RegistryWith(capture);
+        var target = new CaptureTarget();
+
+        for (int i = 0; i < 5; i++)
+        {
+            var s = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", i });
+            DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "r", null, in s);
+        }
+
+        // maxHits=2 → only 2 captures should have proceeded.
+        DIDataStore.Drain().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CapturesTraceContext_WhenActivityPresent()
+    {
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        using var activitySource = new ActivitySource("test-source");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = activitySource.StartActivity("op");
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "r", null, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.TraceId.Should().NotBeNullOrEmpty();
+        cap.SpanId.Should().NotBeNullOrEmpty();
+        cap.TraceId.Should().Be(activity!.TraceId.ToHexString());
+    }
+
+    [Fact]
+    public void OnMethodEnd_WithoutMatchingBegin_DoesNotThrowOrEnqueue()
+    {
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        // Default state (no begin recorded) → end should be a no-op.
+        var act = () => { _ = DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(
+            target, "r", null, in CallTargetStateHolder.Default); };
+        act.Should().NotThrow();
+        DIDataStore.Drain().Should().BeEmpty();
+    }
+}
+
+// Target types for the pipeline tests. FullName of CaptureTarget must equal
+// CodeUnit + ".CaptureTarget".
+public class CaptureTarget
+{
+    public string Process(string orderId, int quantity) => $"{orderId}:{quantity}";
+}
+
+public class UnrelatedTarget
+{
+    public int Compute(int x) => x;
+}
+
+// Helper to obtain a default CallTargetState for the "no matching begin" test.
+internal static class CallTargetStateHolder
+{
+    public static readonly CallTargetState Default = CallTargetState.GetDefault();
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/CapturePipelineTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/CapturePipelineTests.cs
@@ -141,6 +141,27 @@ public class CapturePipelineTests : IDisposable
     }
 
     [Fact]
+    public void NamedArguments_MoreNamesThanArgs_CapturesOnlyPresentArgs()
+    {
+        // Filter names three args but only two are passed — capture the two that exist, no crash and no
+        // phantom third entry. (Pins the #4 rewrite: count is min(args.Length, filter.Length).)
+        var capture = CaptureConfiguration.Default with
+        {
+            CaptureArguments = new[] { "orderId", "quantity", "missing" },
+        };
+        RegistryWith(capture);
+        var target = new CaptureTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "ORD", 5 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "r", null, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.Arguments!.Keys.Should().BeEquivalentTo(new[] { "orderId", "quantity" });
+        cap.Arguments["orderId"].Value.Should().Be("ORD");
+        cap.Arguments["quantity"].Value.Should().Be("5");
+    }
+
+    [Fact]
     public void CaptureReturnFalse_OmitsReturnValue()
     {
         var capture = CaptureConfiguration.Default with { CaptureReturn = false };
@@ -211,6 +232,82 @@ public class CapturePipelineTests : IDisposable
     }
 
     [Fact]
+    public void CoLocatedMethods_ResolveByArity_AttributeToCorrectProbe()
+    {
+        // #3 fix, end-to-end through the capture hot path: two instrumented methods on ONE type,
+        // differing in parameter count. Each woven call must attribute to its own config (LocationHash),
+        // not "first key wins". Arity comes from args.Length, indexed via IndexArities (Apply-time).
+        var registry = new InstrumentationRegistry();
+        var oneArg = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = CodeUnit,
+            ClassName = "MultiMethodTarget",
+            MethodName = "Process",
+            LocationHash = "loc-one-arg",
+            Capture = CaptureConfiguration.Default,
+        };
+        var twoArg = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = CodeUnit,
+            ClassName = "MultiMethodTarget",
+            MethodName = "Validate",
+            LocationHash = "loc-two-arg",
+            Capture = CaptureConfiguration.Default,
+        };
+        registry.Register(oneArg);
+        registry.Register(twoArg);
+        registry.IndexArities($"{CodeUnit}.MultiMethodTarget", oneArg.InstrumentationKey, new[] { 1 });
+        registry.IndexArities($"{CodeUnit}.MultiMethodTarget", twoArg.InstrumentationKey, new[] { 2 });
+        DiIntegrationHelper.Configure(registry);
+
+        var target = new MultiMethodTarget();
+
+        // Arity-1 call → must resolve to the one-arg config.
+        var s1 = DiIntegrationHelper.OnMethodBegin<MultiMethodTarget>(target, new object?[] { "x" });
+        DiIntegrationHelper.OnMethodEnd<MultiMethodTarget, string>(target, "r", null, in s1);
+
+        // Arity-2 call → must resolve to the two-arg config.
+        var s2 = DiIntegrationHelper.OnMethodBegin<MultiMethodTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<MultiMethodTarget, string>(target, "r", null, in s2);
+
+        var caps = DIDataStore.Drain();
+        caps.Should().HaveCount(2);
+        caps.Should().ContainSingle(c => c.LocationHash == "loc-one-arg"
+                                      && c.InstrumentationKey == oneArg.InstrumentationKey);
+        caps.Should().ContainSingle(c => c.LocationHash == "loc-two-arg"
+                                      && c.InstrumentationKey == twoArg.InstrumentationKey);
+    }
+
+    [Fact]
+    public void RecursiveCalls_NestedBeginEnd_BothCapturesSurviveWithOwnEntryData()
+    {
+        // #1 fix, end-to-end through the helper (not just DIDataStore): a recursive call nests
+        // Begin(outer) → Begin(inner) → End(inner) → End(outer) on the SAME method. The per-call id in
+        // CaptureState must pair each End with ITS OWN entry — the inner End must not consume the outer's
+        // pending entry. Before the fix the store keyed by instrumentation key, so the inner frame
+        // overwrote the outer's entry and the outer capture was silently dropped.
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        var outer = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "OUTER", 1 });
+        var inner = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "INNER", 2 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "inner-ret", null, in inner);
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "outer-ret", null, in outer);
+
+        var caps = DIDataStore.Drain();
+        caps.Should().HaveCount(2, "both the outer and inner invocations must emit a capture");
+
+        // Each capture kept its OWN entry data (args captured at its Begin, return at its End) — proving
+        // the frames were paired independently rather than one clobbering the other.
+        caps.Should().ContainSingle(c => c.Arguments!["arg0"].Value == "INNER"
+                                      && c.ReturnValue!.Value == "inner-ret");
+        caps.Should().ContainSingle(c => c.Arguments!["arg0"].Value == "OUTER"
+                                      && c.ReturnValue!.Value == "outer-ret");
+    }
+
+    [Fact]
     public void OnMethodEnd_WithoutMatchingBegin_DoesNotThrowOrEnqueue()
     {
         RegistryWith(CaptureConfiguration.Default);
@@ -234,6 +331,15 @@ public class CaptureTarget
 public class UnrelatedTarget
 {
     public int Compute(int x) => x;
+}
+
+// Two instrumented methods on one type, differing in parameter count — the #3 arity-disambiguation
+// case. FullName must equal CodeUnit + ".MultiMethodTarget".
+public class MultiMethodTarget
+{
+    public string Process(string orderId) => orderId;
+
+    public string Validate(string orderId, int quantity) => $"{orderId}:{quantity}";
 }
 
 // Helper to obtain a default CallTargetState for the "no matching begin" test.

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/CapturePipelineTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/CapturePipelineTests.cs
@@ -308,6 +308,105 @@ public class CapturePipelineTests : IDisposable
     }
 
     [Fact]
+    public void AsyncMethod_SyncEndDefers_AsyncEndCapturesUnwrappedResult()
+    {
+        // For a Task<T>-returning method the profiler calls the sync OnMethodEnd with the INCOMPLETE task,
+        // then OnAsyncMethodEnd with the completed, unwrapped result. The sync end must defer (capture
+        // nothing, leave the paired entry intact) so we never serialize an incomplete Task; the async end
+        // then produces exactly one capture carrying the unwrapped value.
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "ORD-9", 3 });
+
+        // Sync end fires first with the still-running task — must be a no-op.
+        var runningTask = new TaskCompletionSource<string>().Task; // never completes
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, Task<string>>(target, runningTask, null, in state);
+        DIDataStore.Drain().Should().BeEmpty("the synchronous end must defer for an awaitable return");
+
+        // Async end fires on completion with the unwrapped T ("done") and no exception.
+        DiIntegrationHelper.OnAsyncMethodEnd<CaptureTarget, string>(target, "done", null, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.Arguments!["arg0"].Value.Should().Be("ORD-9");
+        cap.ReturnValue!.Value.Should().Be("done", "the captured value is the awaited result, not the Task");
+        cap.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void AsyncMethod_FaultedTask_CapturesExceptionViaAsyncEnd()
+    {
+        // A faulted async method: the profiler awaits, then calls OnAsyncMethodEnd with the fault. The
+        // capture must record the exception (the sync end having deferred).
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+        var ex = new InvalidOperationException("async-boom");
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, Task<string>>(target, Task.FromResult("ignored"), null, in state);
+        DiIntegrationHelper.OnAsyncMethodEnd<CaptureTarget, string>(target, null!, ex, in state);
+
+        var cap = DIDataStore.Drain().Single();
+        cap.Exception.Should().NotBeNull();
+        cap.Exception!.Type.Should().Be("System.InvalidOperationException");
+        cap.Exception.Value.Should().Be("async-boom");
+    }
+
+    [Fact]
+    public void NonGenericTask_SyncEndDefers_AsyncEndCaptures()
+    {
+        // Task (non-generic) / ValueTask returns unwrap to a null object. The sync end still defers; the
+        // async end produces the capture with a null return value.
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, Task>(target, Task.CompletedTask, null, in state);
+        DIDataStore.Drain().Should().BeEmpty();
+
+        DiIntegrationHelper.OnAsyncMethodEnd<CaptureTarget, object?>(target, null, null, in state);
+        DIDataStore.Drain().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void SyncMethod_StillCapturesOnSyncEnd()
+    {
+        // Guard against over-broad deferral: a plain (non-awaitable) return must still capture on the
+        // synchronous end exactly as before.
+        RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        var state = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "sync-result", null, in state);
+
+        DIDataStore.Drain().Single().ReturnValue!.Value.Should().Be("sync-result");
+    }
+
+    [Fact]
+    public void RemovedConfig_WovenCallbackNoOps_ProducesNoCapture()
+    {
+        // Uninstrument is logical, not physical: the profiler has no revert export, so a removed config's
+        // method stays woven. Proving the reviewer's concern: once the config is dropped from the registry,
+        // the still-firing callback must capture NOTHING. RemoveStale with an empty active set drops the key;
+        // a subsequent Begin/End cycle (simulating the still-woven method being called) must be a no-op.
+        var registry = RegistryWith(CaptureConfiguration.Default);
+        var target = new CaptureTarget();
+
+        // Sanity: while registered, it captures.
+        var s1 = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 1 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "r", null, in s1);
+        DIDataStore.Drain().Should().HaveCount(1);
+
+        // Backend removes the config → registry drops it (mirrors OnConfigurationsChanged's RemoveStale).
+        registry.RemoveStale(new HashSet<string>()).Should().NotBeEmpty();
+
+        // The method is still woven; the callback still fires — but now finds no config and must no-op.
+        var s2 = DiIntegrationHelper.OnMethodBegin<CaptureTarget>(target, new object?[] { "x", 2 });
+        DiIntegrationHelper.OnMethodEnd<CaptureTarget, string>(target, "r", null, in s2);
+        DIDataStore.Drain().Should().BeEmpty("a removed config must produce no captures even though the method stays woven");
+    }
+
+    [Fact]
     public void OnMethodEnd_WithoutMatchingBegin_DoesNotThrowOrEnqueue()
     {
         RegistryWith(CaptureConfiguration.Default);

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/DiIntegrationHelperTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/DiIntegrationHelperTests.cs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation.FunctionLevel;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation;
+
+public class DiIntegrationHelperTests
+{
+    private static InstrumentationConfiguration Config(string codeUnit, string className, string method = "Process") =>
+        new()
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = codeUnit,
+            ClassName = className,
+            MethodName = method,
+            LocationHash = $"{codeUnit}.{className}",
+            Capture = CaptureConfiguration.Default
+        };
+
+    [Fact]
+    public void MatchKeyByType_ExactMatch_ReturnsKey()
+    {
+        var registry = new InstrumentationRegistry();
+        registry.Register(Config("MyApp.Services", "OrderService"));
+
+        var key = DiIntegrationHelper.MatchKeyByType("MyApp.Services.OrderService", registry);
+
+        key.Should().Be("MyApp.Services.OrderService.Process");
+    }
+
+    [Fact]
+    public void MatchKeyByType_SameClassNameDifferentNamespace_DoesNotCollide()
+    {
+        // Regression for C4: two classes named "Svc" in different namespaces must not
+        // collide. Only the exact fully-qualified match should win.
+        var registry = new InstrumentationRegistry();
+        registry.Register(Config("A", "Svc"));
+        registry.Register(Config("B", "Svc"));
+
+        DiIntegrationHelper.MatchKeyByType("A.Svc", registry).Should().Be("A.Svc.Process");
+        DiIntegrationHelper.MatchKeyByType("B.Svc", registry).Should().Be("B.Svc.Process");
+    }
+
+    [Fact]
+    public void MatchKeyByType_SuffixButNotExact_ReturnsNull()
+    {
+        // "Other.OrderService" must NOT match a registered "MyApp.Services.OrderService"
+        // just because the class name suffix lines up.
+        var registry = new InstrumentationRegistry();
+        registry.Register(Config("MyApp.Services", "OrderService"));
+
+        DiIntegrationHelper.MatchKeyByType("Other.OrderService", registry).Should().BeNull();
+    }
+
+    [Fact]
+    public void MatchKeyByType_NoMatch_ReturnsNull()
+    {
+        var registry = new InstrumentationRegistry();
+        registry.Register(Config("MyApp", "A"));
+
+        DiIntegrationHelper.MatchKeyByType("MyApp.B", registry).Should().BeNull();
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/InstrumentationApplyResultExtensionsTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/InstrumentationApplyResultExtensionsTests.cs
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation;
+
+// Pins the instrumentation-failed error taxonomy: which apply results are reportable ERRORs and how
+// each maps to the backend InstrumentationErrorCause wire value. This is distinct from capture-failed
+// (NotCapturedReason), which is never an ERROR on the configuration.
+//
+// The cases live inside [Fact] bodies rather than [Theory]/[InlineData] because InstrumentationApplyResult
+// is internal and cannot appear in a public test method signature (CS0051).
+public class InstrumentationApplyResultExtensionsTests
+{
+    [Fact]
+    public void IsReportableFailure_ClassifiesPermanentFailuresOnly()
+    {
+        InstrumentationApplyResult.MethodNotFound.IsReportableFailure().Should().BeTrue();
+        InstrumentationApplyResult.NoSupportedArity.IsReportableFailure().Should().BeTrue();
+        InstrumentationApplyResult.RuntimeError.IsReportableFailure().Should().BeTrue();
+
+        InstrumentationApplyResult.Applied.IsReportableFailure().Should().BeFalse();
+        InstrumentationApplyResult.Skipped.IsReportableFailure().Should().BeFalse();
+        InstrumentationApplyResult.TypeNotLoaded.IsReportableFailure().Should().BeFalse(); // transient: retried, never reported
+    }
+
+    [Fact]
+    public void MapErrorCause_ReturnsBackendCause_ForReportableFailures()
+    {
+        InstrumentationApplyResult.MethodNotFound.MapErrorCause().Should().Be("METHOD_NOT_FOUND");
+        InstrumentationApplyResult.NoSupportedArity.MapErrorCause().Should().Be("RUNTIME_ERROR"); // >9 params: no bespoke cause
+        InstrumentationApplyResult.RuntimeError.MapErrorCause().Should().Be("RUNTIME_ERROR");
+    }
+
+    [Fact]
+    public void MapErrorCause_ReturnsNull_ForNonFailures()
+    {
+        InstrumentationApplyResult.Applied.MapErrorCause().Should().BeNull();
+        InstrumentationApplyResult.Skipped.MapErrorCause().Should().BeNull();
+        InstrumentationApplyResult.TypeNotLoaded.MapErrorCause().Should().BeNull();
+    }
+
+    [Fact]
+    public void MapErrorCause_AndIsReportable_AgreeOnEveryResult()
+    {
+        // Invariant the PR3 emission relies on: a result has a non-null cause exactly when it is reportable.
+        foreach (InstrumentationApplyResult result in Enum.GetValues<InstrumentationApplyResult>())
+        {
+            (result.MapErrorCause() != null).Should().Be(
+                result.IsReportableFailure(),
+                "cause presence must match reportability for {0}", result);
+        }
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/InstrumentationRegistryTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/InstrumentationRegistryTests.cs
@@ -155,4 +155,143 @@ public class InstrumentationRegistryTests
 
         registry.GetAll().Should().HaveCount(3);
     }
+
+    [Fact]
+    public void TryResolveKeyByType_ResolvesRegisteredTypeViaIndex()
+    {
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+
+        registry.Register(config);
+
+        // MyApp.Svc -> the registered key, resolved by the TypeName index (not a scan).
+        registry.TryResolveKeyByType("MyApp.Svc").Should().Be(config.InstrumentationKey);
+        registry.TryResolveKeyByType("Not.Registered").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolveKeyByType_AfterRemoveStale_NoLongerResolves()
+    {
+        // The TypeName index must stay in sync with RemoveStale: once the only config for a type is
+        // dropped, that type must stop resolving (otherwise a woven call resolves to a dead key).
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+        registry.Register(config);
+        registry.TryResolveKeyByType("MyApp.Svc").Should().NotBeNull();
+
+        registry.RemoveStale(new HashSet<string>()); // nothing active → remove all
+
+        registry.TryResolveKeyByType("MyApp.Svc").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolveKeyByType_MultipleMethodsSameType_ReturnsNull_ThenResolvesWhenUnambiguous()
+    {
+        // Type-only resolution must NOT guess among multiple configs on one type: guessing wrong
+        // misattributes a capture to the wrong probe (worse than dropping it, see #3). So while two
+        // methods are registered it returns null; once only one remains it's unambiguous and resolves.
+        var registry = new InstrumentationRegistry();
+        var a = CreateConfig(locationHash: "ha", method: "A");
+        var b = CreateConfig(locationHash: "hb", method: "B");
+        registry.Register(a);
+        registry.Register(b);
+
+        // Two configs on MyApp.Svc → ambiguous by type alone → null (drop rather than misattribute).
+        registry.TryResolveKeyByType("MyApp.Svc").Should().BeNull();
+
+        // Drop A; the type now hosts exactly one config → unambiguous → resolves to the survivor.
+        registry.RemoveStale(new HashSet<string> { b.InstrumentationKey });
+        registry.TryResolveKeyByType("MyApp.Svc").Should().Be(b.InstrumentationKey);
+    }
+
+    [Fact]
+    public void TryResolveKeyByTypeAndArity_DifferentArities_DisambiguatesCoLocatedMethods()
+    {
+        // The core #3 fix: two methods on one type, one arg-count each. A woven call resolves to the
+        // config whose method has the matching parameter count — not "first key wins".
+        var registry = new InstrumentationRegistry();
+        var oneArg = CreateConfig(locationHash: "h1", method: "Process");
+        var twoArg = CreateConfig(locationHash: "h2", method: "Validate");
+        registry.Register(oneArg);
+        registry.Register(twoArg);
+        registry.IndexArities("MyApp.Svc", oneArg.InstrumentationKey, new[] { 1 });
+        registry.IndexArities("MyApp.Svc", twoArg.InstrumentationKey, new[] { 2 });
+
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 1).Should().Be(oneArg.InstrumentationKey);
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 2).Should().Be(twoArg.InstrumentationKey);
+    }
+
+    [Fact]
+    public void TryResolveKeyByTypeAndArity_UnindexedArity_ReturnsNull()
+    {
+        // Resolution is precise: an arity that was never indexed does not resolve (caller falls back to
+        // the type-only index).
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+        registry.Register(config);
+        registry.IndexArities("MyApp.Svc", config.InstrumentationKey, new[] { 1 });
+
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 2).Should().BeNull();
+        registry.TryResolveKeyByTypeAndArity("Not.Registered", 1).Should().BeNull();
+    }
+
+    [Fact]
+    public void IndexArities_Overloads_IndexEachArity()
+    {
+        // One config can weave several arities (overloaded method) — each must resolve to that config.
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+        registry.Register(config);
+        registry.IndexArities("MyApp.Svc", config.InstrumentationKey, new[] { 0, 1, 3 });
+
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 0).Should().Be(config.InstrumentationKey);
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 1).Should().Be(config.InstrumentationKey);
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 3).Should().Be(config.InstrumentationKey);
+    }
+
+    [Fact]
+    public void IndexArities_SameArityTwoMethods_ReportsCollision()
+    {
+        // The documented #3 residual: two methods on one type sharing a parameter count are
+        // indistinguishable at capture time (args.Length can't separate them). IndexArities flags it.
+        var registry = new InstrumentationRegistry();
+        var a = CreateConfig(locationHash: "ha", method: "Process");
+        var b = CreateConfig(locationHash: "hb", method: "Validate");
+        registry.Register(a);
+        registry.Register(b);
+
+        // First method at arity 1: no prior key → no collision.
+        registry.IndexArities("MyApp.Svc", a.InstrumentationKey, new[] { 1 }).Should().BeFalse();
+
+        // Second method also at arity 1: collides with the first.
+        registry.IndexArities("MyApp.Svc", b.InstrumentationKey, new[] { 1 }).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IndexArities_SameKeyReindexed_DoesNotReportCollision()
+    {
+        // Re-applying the same config (e.g. a later poll) must not be mistaken for a collision.
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+        registry.Register(config);
+
+        registry.IndexArities("MyApp.Svc", config.InstrumentationKey, new[] { 1 }).Should().BeFalse();
+        registry.IndexArities("MyApp.Svc", config.InstrumentationKey, new[] { 1 }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryResolveKeyByTypeAndArity_AfterRemoveStale_NoLongerResolves()
+    {
+        // The arity index must stay in sync with RemoveStale, exactly like the type-only index — a dropped
+        // config must stop resolving by arity too, or a woven call resolves to a dead key.
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+        registry.Register(config);
+        registry.IndexArities("MyApp.Svc", config.InstrumentationKey, new[] { 1 });
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 1).Should().NotBeNull();
+
+        registry.RemoveStale(new HashSet<string>()); // nothing active → remove all
+
+        registry.TryResolveKeyByTypeAndArity("MyApp.Svc", 1).Should().BeNull();
+    }
 }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/InstrumentationRegistryTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/InstrumentationRegistryTests.cs
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation;
+
+public class InstrumentationRegistryTests
+{
+    private static InstrumentationConfiguration CreateConfig(
+        string locationHash = "hash1",
+        string method = "Process",
+        DateTimeOffset? createdAt = null) =>
+        new()
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = "MyApp",
+            ClassName = "Svc",
+            MethodName = method,
+            LocationHash = locationHash,
+            CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
+            Capture = CaptureConfiguration.Default
+        };
+
+    [Fact]
+    public void Register_AddsConfig()
+    {
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+
+        registry.Register(config);
+
+        registry.Count.Should().Be(1);
+        registry.Get(config.InstrumentationKey).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Register_SameConfig_PreservesHitState()
+    {
+        var registry = new InstrumentationRegistry();
+        var created = DateTimeOffset.UtcNow;
+        var config = CreateConfig(createdAt: created);
+
+        registry.Register(config);
+        registry.TryHit(config.InstrumentationKey); // increment hit count
+
+        // Re-register same config (same locationHash + createdAt)
+        var sameConfig = CreateConfig(createdAt: created);
+        registry.Register(sameConfig);
+
+        // Hit state preserved — count should still be 1
+        var reg = registry.Get(config.InstrumentationKey);
+        reg!.HitState.HitCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Register_ChangedConfig_ResetsHitState()
+    {
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig(locationHash: "v1", createdAt: DateTimeOffset.UtcNow);
+
+        registry.Register(config);
+        registry.TryHit(config.InstrumentationKey);
+
+        // Re-register with different locationHash (config changed)
+        var newConfig = CreateConfig(locationHash: "v2", createdAt: DateTimeOffset.UtcNow);
+        registry.Register(newConfig);
+
+        var reg = registry.Get(newConfig.InstrumentationKey);
+        reg!.HitState.HitCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void RemoveStale_RemovesConfigsNotInActiveSet()
+    {
+        var registry = new InstrumentationRegistry();
+        var config1 = CreateConfig(method: "A");
+        var config2 = CreateConfig(method: "B");
+
+        registry.Register(config1);
+        registry.Register(config2);
+
+        var activeKeys = new HashSet<string> { config1.InstrumentationKey };
+        var removed = registry.RemoveStale(activeKeys);
+
+        removed.Should().Contain(config2.InstrumentationKey);
+        registry.Count.Should().Be(1);
+        registry.Get(config2.InstrumentationKey).Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoveStale_KeepsActiveConfigs()
+    {
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+
+        registry.Register(config);
+
+        var activeKeys = new HashSet<string> { config.InstrumentationKey };
+        var removed = registry.RemoveStale(activeKeys);
+
+        removed.Should().BeEmpty();
+        registry.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryHit_RegisteredConfig_ReturnsTrue()
+    {
+        var registry = new InstrumentationRegistry();
+        var config = CreateConfig();
+        registry.Register(config);
+
+        registry.TryHit(config.InstrumentationKey).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryHit_UnknownKey_ReturnsFalse()
+    {
+        var registry = new InstrumentationRegistry();
+
+        registry.TryHit("nonexistent.key").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryHit_DisabledConfig_ReturnsFalse()
+    {
+        var registry = new InstrumentationRegistry();
+        var config = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.BREAKPOINT,
+            CodeUnit = "MyApp",
+            ClassName = "Svc",
+            MethodName = "Limited",
+            LocationHash = "hash1",
+            Capture = new CaptureConfiguration(
+                null, null, true, false,
+                255, 20, 3, 3, 20, 20, MaxHits: 2)
+        };
+
+        registry.Register(config);
+
+        registry.TryHit(config.InstrumentationKey).Should().BeTrue();  // 1
+        registry.TryHit(config.InstrumentationKey).Should().BeTrue();  // 2
+        registry.TryHit(config.InstrumentationKey).Should().BeFalse(); // 3 — maxHits exceeded
+    }
+
+    [Fact]
+    public void GetAll_ReturnsAllRegistered()
+    {
+        var registry = new InstrumentationRegistry();
+        registry.Register(CreateConfig(method: "A"));
+        registry.Register(CreateConfig(method: "B"));
+        registry.Register(CreateConfig(method: "C"));
+
+        registry.GetAll().Should().HaveCount(3);
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/ProfilerTranslatorTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/ProfilerTranslatorTests.cs
@@ -1,0 +1,281 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Instrumentation;
+using AWS.Distro.OpenTelemetry.DynamicInstrumentation.Model;
+
+namespace AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation;
+
+public class ProfilerTranslatorTests
+{
+    private static InstrumentationConfiguration CreateConfig(
+        string methodName = "Process",
+        int lineNumber = 0,
+        InstrumentationType type = InstrumentationType.PROBE) =>
+        new()
+        {
+            Type = type,
+            CodeUnit = "MyApp.Services",
+            ClassName = "OrderService",
+            MethodName = methodName,
+            LineNumber = lineNumber,
+            LocationHash = "aabb000000000001",
+            Capture = CaptureConfiguration.Default
+        };
+
+    // A method resolver stub that reports a fixed set of overload arities and assembly name.
+    private static Func<InstrumentationConfiguration, MethodResolution?> Resolver(
+        string assembly, params int[] arities) =>
+        _ => new MethodResolution(assembly, arities.ToHashSet());
+
+    private static readonly Func<InstrumentationConfiguration, MethodResolution?> Unresolvable = _ => null;
+
+    [Fact]
+    public void ApplyInstrumentation_MethodLevel_CallsAddInstrumentations()
+    {
+        string? capturedId = null;
+        NativeCallTargetDefinition[]? capturedDefs = null;
+
+        var translator = new ProfilerTranslator(
+            (id, defs, size) => { capturedId = id; capturedDefs = defs; },
+            Resolver("MyApp", 2));
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        result.Should().Be(InstrumentationApplyResult.Applied);
+        capturedId.Should().Be("aabb000000000001");
+        capturedDefs.Should().NotBeNull();
+        capturedDefs!.Length.Should().Be(1);
+        capturedDefs[0].TargetType.Should().Be("MyApp.Services.OrderService");
+        capturedDefs[0].TargetMethod.Should().Be("Process");
+        capturedDefs[0].TargetAssembly.Should().Be("MyApp");
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_ResolvesArity_PicksMatchingIntegration()
+    {
+        string? integrationType = null;
+        var translator = new ProfilerTranslator(
+            (_, defs, _) => integrationType = defs[0].IntegrationType,
+            Resolver("MyApp", 2));
+
+        translator.ApplyInstrumentation(CreateConfig());
+
+        integrationType.Should().EndWith("DiIntegration2");
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_ZeroArity_UsesDiIntegration0()
+    {
+        string? integrationType = null;
+        var translator = new ProfilerTranslator(
+            (_, defs, _) => integrationType = defs[0].IntegrationType,
+            Resolver("MyApp", 0));
+
+        translator.ApplyInstrumentation(CreateConfig());
+
+        integrationType.Should().EndWith("DiIntegration0");
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_SignatureArrayLength_MatchesArityPlusOne()
+    {
+        // Verified against the real profiler: it selects by signature-array length
+        // (arity + 1), with "_" wildcards for the individual types.
+        NativeCallTargetDefinition[]? defs = null;
+        var translator = new ProfilerTranslator((_, d, _) => defs = d, Resolver("MyApp", 3));
+
+        translator.ApplyInstrumentation(CreateConfig());
+
+        defs![0].TargetSignatureTypesLength.Should().Be(4); // return + 3 params
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_Overloads_RegistersOneDefinitionPerArity()
+    {
+        NativeCallTargetDefinition[]? defs = null;
+        var translator = new ProfilerTranslator((_, d, _) => defs = d, Resolver("MyApp", 1, 2, 3));
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        result.Should().Be(InstrumentationApplyResult.Applied);
+        defs!.Length.Should().Be(3);
+        defs.Select(d => (int)d.TargetSignatureTypesLength).Should().BeEquivalentTo(new[] { 2, 3, 4 });
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_UnresolvableTarget_ReportsTypeNotLoaded()
+    {
+        bool registered = false;
+        var translator = new ProfilerTranslator((_, _, _) => registered = true, Unresolvable);
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        // A null resolution means the type isn't in any loaded assembly — transient, retry-worthy.
+        result.Should().Be(InstrumentationApplyResult.TypeNotLoaded);
+        registered.Should().BeFalse(); // never registers when arity can't be resolved
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_MethodMissingOnLoadedType_ReportsMethodNotFound()
+    {
+        // Type resolved (non-null) but exposes no method by that name (empty arities) — a genuine
+        // misconfiguration, distinct from a not-yet-loaded type.
+        bool registered = false;
+        var translator = new ProfilerTranslator(
+            (_, _, _) => registered = true,
+            _ => new MethodResolution("MyApp", new HashSet<int>()));
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        result.Should().Be(InstrumentationApplyResult.MethodNotFound);
+        registered.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_ArityExceedsMax_ReportsNoSupportedArity()
+    {
+        bool registered = false;
+        var translator = new ProfilerTranslator((_, _, _) => registered = true, Resolver("MyApp", 10));
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        result.Should().Be(InstrumentationApplyResult.NoSupportedArity);
+        registered.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_MixedArities_SkipsOverMaxKeepsValid()
+    {
+        NativeCallTargetDefinition[]? defs = null;
+        var translator = new ProfilerTranslator((_, d, _) => defs = d, Resolver("MyApp", 2, 15));
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        result.Should().Be(InstrumentationApplyResult.Applied);
+        defs!.Length.Should().Be(1); // arity 15 dropped, arity 2 kept
+        defs[0].TargetSignatureTypesLength.Should().Be(3);
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_LineLevelConfig_ReportsSkipped()
+    {
+        var translator = new ProfilerTranslator((_, _, _) => { }, Resolver("MyApp", 2));
+        var result = translator.ApplyInstrumentation(CreateConfig(lineNumber: 42));
+        result.Should().Be(InstrumentationApplyResult.Skipped);
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_Constructor_ReportsSkipped()
+    {
+        var translator = new ProfilerTranslator((_, _, _) => { }, Resolver("MyApp", 0));
+        var result = translator.ApplyInstrumentation(CreateConfig(methodName: ".ctor"));
+        result.Should().Be(InstrumentationApplyResult.Skipped);
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_StaticConstructor_ReportsSkipped()
+    {
+        var translator = new ProfilerTranslator((_, _, _) => { }, Resolver("MyApp", 0));
+        var result = translator.ApplyInstrumentation(CreateConfig(methodName: ".cctor"));
+        result.Should().Be(InstrumentationApplyResult.Skipped);
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_ExceptionInNativeCall_ReportsRuntimeError()
+    {
+        var translator = new ProfilerTranslator(
+            (_, _, _) => throw new DllNotFoundException("profiler not loaded"),
+            Resolver("MyApp", 2));
+
+        var result = translator.ApplyInstrumentation(CreateConfig());
+
+        result.Should().Be(InstrumentationApplyResult.RuntimeError);
+    }
+
+    [Fact]
+    public void IsUnsupportedTarget_Constructor_ReturnsTrue()
+    {
+        ProfilerTranslator.IsUnsupportedTarget(CreateConfig(methodName: ".ctor")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnsupportedTarget_StaticConstructor_ReturnsTrue()
+    {
+        ProfilerTranslator.IsUnsupportedTarget(CreateConfig(methodName: ".cctor")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnsupportedTarget_NormalMethod_ReturnsFalse()
+    {
+        ProfilerTranslator.IsUnsupportedTarget(CreateConfig(methodName: "ProcessOrder")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReflectionResolver_ResolvesRealType_ByArity()
+    {
+        // Exercises the real reflection path (no resolver override) against a type in
+        // this test assembly. Proves end-to-end arity resolution without the profiler.
+        NativeCallTargetDefinition[]? defs = null;
+        var translator = new ProfilerTranslator((_, d, _) => defs = d);
+
+        var config = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = "AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation",
+            ClassName = "ReflectionTarget",
+            MethodName = "TwoArgs",
+            LocationHash = "hash",
+            Capture = CaptureConfiguration.Default
+        };
+
+        var result = translator.ApplyInstrumentation(config);
+
+        result.Should().Be(InstrumentationApplyResult.Applied);
+        defs!.Length.Should().Be(1);
+        defs[0].TargetSignatureTypesLength.Should().Be(3); // return + 2 params
+    }
+
+    [Fact]
+    public void ReflectionResolver_UnknownType_ReportsTypeNotLoaded()
+    {
+        var translator = new ProfilerTranslator((_, _, _) => { });
+        var config = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = "No.Such.Namespace",
+            ClassName = "Nope",
+            MethodName = "X",
+            LocationHash = "hash",
+            Capture = CaptureConfiguration.Default
+        };
+
+        translator.ApplyInstrumentation(config).Should().Be(InstrumentationApplyResult.TypeNotLoaded);
+    }
+
+    [Fact]
+    public void ReflectionResolver_KnownTypeMissingMethod_ReportsMethodNotFound()
+    {
+        // ReflectionTarget exists in this assembly but has no method "DoesNotExist" — the resolver
+        // returns a non-null resolution with empty arities, which maps to MethodNotFound (not the
+        // transient TypeNotLoaded).
+        var translator = new ProfilerTranslator((_, _, _) => { });
+        var config = new InstrumentationConfiguration
+        {
+            Type = InstrumentationType.PROBE,
+            CodeUnit = "AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests.Instrumentation",
+            ClassName = "ReflectionTarget",
+            MethodName = "DoesNotExist",
+            LocationHash = "hash",
+            Capture = CaptureConfiguration.Default
+        };
+
+        translator.ApplyInstrumentation(config).Should().Be(InstrumentationApplyResult.MethodNotFound);
+    }
+}
+
+// Target type for the real-reflection test above.
+public class ReflectionTarget
+{
+    public string TwoArgs(string a, int b) => $"{a}{b}";
+}

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/ProfilerTranslatorTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Instrumentation/ProfilerTranslatorTests.cs
@@ -104,6 +104,32 @@ public class ProfilerTranslatorTests
     }
 
     [Fact]
+    public void ApplyInstrumentation_Applied_SurfacesSupportedArities()
+    {
+        // The out overload reports the woven arities so the Manager can index them for arity-aware
+        // capture resolution (#3). Only profiler-supported arities appear (15 dropped, 2 kept).
+        var translator = new ProfilerTranslator((_, _, _) => { }, Resolver("MyApp", 2, 15));
+
+        var result = translator.ApplyInstrumentation(CreateConfig(), out var arities);
+
+        result.Should().Be(InstrumentationApplyResult.Applied);
+        arities.Should().BeEquivalentTo(new[] { 2 });
+    }
+
+    [Fact]
+    public void ApplyInstrumentation_NativeThrows_SurfacesNoArities()
+    {
+        // On a native throw nothing was woven, so nothing must be indexed.
+        var translator = new ProfilerTranslator(
+            (_, _, _) => throw new DllNotFoundException("boom"), Resolver("MyApp", 2));
+
+        var result = translator.ApplyInstrumentation(CreateConfig(), out var arities);
+
+        result.Should().Be(InstrumentationApplyResult.RuntimeError);
+        arities.Should().BeEmpty();
+    }
+
+    [Fact]
     public void ApplyInstrumentation_UnresolvableTarget_ReportsTypeNotLoaded()
     {
         bool registered = false;

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Model/HitStateTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Model/HitStateTests.cs
@@ -106,4 +106,124 @@ public class HitStateTests
 
         state.IsDisabled.Should().BeFalse();
     }
+
+    [Fact]
+    public void TryHit_ExactlyMaxHitsAllowed_ThenMaxPlusOneBlocked()
+    {
+        var state = new HitState(maxHits: 5, expiresAt: null, maxCapturesPerSecond: 100);
+
+        // Exactly maxHits (5) captures are allowed: count reaches maxHits without exceeding it.
+        for (int i = 0; i < 5; i++)
+            state.TryHit().Should().BeTrue();
+
+        state.HitCount.Should().Be(5);
+        state.IsDisabled.Should().BeFalse();
+
+        // The (maxHits + 1)th capture is blocked and disables the state.
+        state.TryHit().Should().BeFalse();
+        state.IsDisabled.Should().BeTrue();
+        state.Reason.Should().Be(DisableReason.MAX_HITS_EXCEEDED);
+    }
+
+    [Fact]
+    public void TryHit_RateWindowElapses_WindowCounterResets_AllowsAgain()
+    {
+        // maxHits null (unlimited) isolates the fixed-window rate limiter behavior.
+        var state = new HitState(maxHits: null, expiresAt: null, maxCapturesPerSecond: 2);
+
+        state.TryHit().Should().BeTrue();  // window 1, hit 1
+        state.TryHit().Should().BeTrue();  // window 1, hit 2
+        state.TryHit().Should().BeFalse(); // window 1, hit 3 — rate limited
+
+        // Let the 1-second fixed window elapse so windowCount resets.
+        Thread.Sleep(1100);
+
+        state.TryHit().Should().BeTrue();  // window 2, hit 1 — allowed again after reset
+        state.TryHit().Should().BeTrue();  // window 2, hit 2
+        state.TryHit().Should().BeFalse(); // window 2, hit 3 — rate limited again
+
+        state.IsDisabled.Should().BeFalse(); // rate limiting never disables the state
+    }
+
+    [Fact]
+    public void TryHit_MaxHits_IsCumulativeTotal_NotPerWindow()
+    {
+        // maxHits is enforced as a running total across ALL rate windows (see IncrementAndCheckMaxHits),
+        // not as a per-second budget. This test pins that behavior.
+        var state = new HitState(maxHits: 3, expiresAt: null, maxCapturesPerSecond: 2);
+
+        state.TryHit().Should().BeTrue();  // total 1
+        state.TryHit().Should().BeTrue();  // total 2
+        state.TryHit().Should().BeFalse(); // rate limited within window 1 (does not count toward maxHits)
+
+        Thread.Sleep(1100); // elapse the rate window so per-second budget resets
+
+        state.TryHit().Should().BeTrue();  // total 3 — new window has rate budget, still under maxHits
+
+        // Even though the fresh window still has rate budget, the cumulative total now exceeds maxHits=3.
+        // TODO(parity): confirm JS/Python treat maxHits the same way (cumulative total) rather than
+        // resetting the maxHits allowance every per-second window.
+        state.TryHit().Should().BeFalse();
+        state.IsDisabled.Should().BeTrue();
+        state.Reason.Should().Be(DisableReason.MAX_HITS_EXCEEDED);
+    }
+
+    [Fact]
+    public void Reason_BeforeAnyDisable_IsNull()
+    {
+        var state = new HitState(maxHits: 5, expiresAt: null);
+
+        state.IsDisabled.Should().BeFalse();
+        state.Reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryHit_ExpiresDuringLifetime_TransitionsFromActiveToDisabledExpired()
+    {
+        var state = new HitState(maxHits: null, expiresAt: DateTimeOffset.UtcNow.AddMilliseconds(300));
+
+        // Active before expiry.
+        state.TryHit().Should().BeTrue();
+        state.IsDisabled.Should().BeFalse();
+        state.Reason.Should().BeNull();
+
+        Thread.Sleep(500); // cross the expiry boundary
+
+        // Expiry is detected lazily on the next TryHit, which disables the state.
+        state.TryHit().Should().BeFalse();
+        state.IsDisabled.Should().BeTrue();
+        state.Reason.Should().Be(DisableReason.EXPIRED_AT);
+    }
+
+    [Fact]
+    public void TryHit_AfterDisabled_DoesNotIncrementHitCount()
+    {
+        var state = new HitState(maxHits: 1, expiresAt: null, maxCapturesPerSecond: 100);
+
+        state.TryHit().Should().BeTrue();  // total 1 (== maxHits, allowed)
+        state.TryHit().Should().BeFalse(); // total 2 exceeds maxHits, disables
+        state.IsDisabled.Should().BeTrue();
+
+        var frozenCount = state.HitCount;
+
+        // Once disabled, TryHit short-circuits before counting.
+        state.TryHit().Should().BeFalse();
+        state.TryHit().Should().BeFalse();
+        state.HitCount.Should().Be(frozenCount);
+    }
+
+    [Fact]
+    public void Reason_LatchesFirstDisableReason_MaxHits()
+    {
+        var state = new HitState(maxHits: 1, expiresAt: null, maxCapturesPerSecond: 100);
+
+        state.TryHit();
+        state.TryHit(); // disables with MAX_HITS_EXCEEDED
+
+        state.Reason.Should().Be(DisableReason.MAX_HITS_EXCEEDED);
+
+        // Reason stays latched across subsequent blocked calls.
+        state.TryHit();
+        state.Reason.Should().Be(DisableReason.MAX_HITS_EXCEEDED);
+    }
 }

--- a/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Model/InstrumentationConfigurationTests.cs
+++ b/test/AWS.Distro.OpenTelemetry.DynamicInstrumentation.Tests/Model/InstrumentationConfigurationTests.cs
@@ -259,6 +259,34 @@ public class InstrumentationConfigurationTests
     }
 
     [Fact]
+    public void Parse_FlatCaptureConfiguration_WithoutCodeCaptureWrapper_ReadsFlatFields()
+    {
+        // Legacy/older backends send the capture fields flat on "CaptureConfiguration" with no
+        // "CodeCapture" wrapper. The flat fields must still be honored (not dropped to Default).
+        var json = """
+        {
+            "InstrumentationType": "BREAKPOINT",
+            "LocationHash": "hash1",
+            "Location": { "CodeLocation": { "CodeUnit": "A", "ClassName": "B", "MethodName": "C" } },
+            "CaptureConfiguration": {
+                "CaptureReturn": true,
+                "CaptureStackTrace": true,
+                "CaptureArguments": ["orderId"],
+                "CaptureLimits": { "MaxStringLength": 200 }
+            }
+        }
+        """;
+
+        var config = InstrumentationConfiguration.Parse(Parse(json));
+
+        config.Should().NotBeNull();
+        config!.Capture.CaptureReturn.Should().BeTrue("flat CaptureReturn must be read");
+        config.Capture.CaptureStackTrace.Should().BeTrue("flat CaptureStackTrace must be read");
+        config.Capture.CaptureArguments.Should().Equal("orderId");
+        config.Capture.MaxStringLength.Should().Be(200);
+    }
+
+    [Fact]
     public void Parse_ProbeMaxHits_IsUnlimited()
     {
         var json = """
@@ -323,6 +351,48 @@ public class InstrumentationConfigurationTests
         var config = InstrumentationConfiguration.Parse(Parse(json));
 
         config.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_MissingClassName_ReturnsNull()
+    {
+        var json = """
+        {
+            "InstrumentationType": "BREAKPOINT",
+            "LocationHash": "hash1",
+            "Location": { "CodeLocation": { "CodeUnit": "A", "MethodName": "C" } }
+        }
+        """;
+
+        InstrumentationConfiguration.Parse(Parse(json)).Should().BeNull("class name is required");
+    }
+
+    [Fact]
+    public void Parse_MissingMethodName_ReturnsNull()
+    {
+        var json = """
+        {
+            "InstrumentationType": "BREAKPOINT",
+            "LocationHash": "hash1",
+            "Location": { "CodeLocation": { "CodeUnit": "A", "ClassName": "B" } }
+        }
+        """;
+
+        InstrumentationConfiguration.Parse(Parse(json)).Should().BeNull("method name is required");
+    }
+
+    [Fact]
+    public void Parse_NegativeLineNumber_ReturnsNull()
+    {
+        var json = """
+        {
+            "InstrumentationType": "BREAKPOINT",
+            "LocationHash": "hash1",
+            "Location": { "CodeLocation": { "CodeUnit": "A", "ClassName": "B", "MethodName": "C", "LineNumber": -5 } }
+        }
+        """;
+
+        InstrumentationConfiguration.Parse(Parse(json)).Should().BeNull("a negative line number is never valid");
     }
 
     // Regression: GetBoolean()/GetInt32()/GetInt64() throw if the field is the wrong JSON kind,


### PR DESCRIPTION
## Issue
AWS customers using .NET applications currently cannot debug production issues without redeploying code. Java ADOT already supports Dynamic Instrumentation (DI) — capturing method arguments, return values, exceptions, and stack traces at runtime by configuring probes through CloudWatch — but .NET has no equivalent. This forces .NET teams into slow redeploy-observe cycles for production debugging.

The foundation layer (boot → configure → poll → parse → state-manage) merged in #421. This PR delivers the capture engine that sits on top of it: it weaves configured target methods using the native CLR profiler already shipped with ADOT .NET (CallTarget approach — no new native dependencies), captures argument/return/exception data at runtime, and enforces per-probe rate limits. The architecture mirrors Java DI's proven design.

Once merged, subsequent PRs wire the output pipeline (PR 3: snapshot export + status reporting) and contract/hardening tests (PR 4) on top of this engine.

## Major Changes
`CallTarget integration callbacks` — DiIntegration0.cs–DiIntegration9.cs (one per parameter arity) + DiIntegrationHelper.cs. The native profiler weaves these into target methods via ReJIT; they capture arguments, return values, and exceptions. Capture logic runs under swallow-and-continue so an agent-internal failure can never propagate into the user's method. Trace/span context is attached from Activity.Current.

`Profiler translation` — ProfilerTranslator.cs resolves the target method's overload arities via reflection and registers NativeCallTargetDefinitions with the profiler (AddInstrumentations P/Invoke, one definition per arity). Returns a typed InstrumentationApplyResult (Applied / TypeNotLoaded / MethodNotFound / NoSupportedArity / RuntimeError) so transient failures (assembly not yet loaded) are retried without spurious error reporting, and permanent failures are reported once.

`Value serialization` — ValueSerializer.cs converts captured objects to CapturedValue trees with clamped depth/width/field-count/string-length limits, reference-cycle detection, and a NotCapturedReason on any truncated value (DEPTH/FIELD_COUNT/COLLECTION_SIZE/ALREADY_CAPTURED).

`Capture store` — DIDataStore.cs is a thread-safe queue pairing method entry/exit into a PendingCapture. Callbacks enqueue here; PR3's collector drains it.

`State management` — InstrumentationRegistry.cs tracks active instrumentations, preserves hit state on unchanged re-registration, and removes stale configs. HitState.cs provides per-probe hit counting, fixed-window rate limiting, max-hits enforcement, and TTL expiry — all thread-safe via Interlocked.

`Manager wiring` — DynamicInstrumentationManager.cs builds the registry + translator before the poller starts and applies each config to the profiler exactly once. Output subsystems land in PR 3; status-reporting call sites are marked TODO(PR3). Added a concurrency guard on OnConfigurationsChanged (the poller invokes it from both the probe and breakpoint threads).

`Wire-contract fixes` — InstrumentationConfiguration.cs / DynamicInstrumentationClient.cs / ConfigurationPoller.cs: SyncedAt/CreatedAt/ExpiresAt are numeric epoch on the wire and are now parsed as such (SyncedAt round-trips as-received); required-field validation drops malformed configs; the flat CaptureConfiguration shape is tolerated.

## Testing done
Unit tests cover the engine and modified foundation code (HTTP tests use a MockHttpHandler stubbing SendAsync to exercise the full production path without network). Beyond unit tests, the engine is verified end-to-end against the real native CLR profiler — the same code path this PR ships:

Real-profiler E2E (ReJIT weave → capture), 8/8: arity 0/1/3, void methods, exceptions, async Task<T>, max-hits gating, and a config parsed from real backend JSON driving the native weave. Asserts directly on DIDataStore output (no dependency on the deferred PR3 output layer).
`PROBE + BREAKPOINT E2E`: mock backend → real client fetch/parse → native profiler weave → capture; PROBE captures every call, BREAKPOINT gates at MaxHits (5 calls → 3 captured).
`Profiler ON/OFF baseline`: identical binary captures with the profiler loaded, 0 captures without it — proving the native profiler (not managed code) performs the weaving; corroborated by the profiler's own ReJIT log naming the rewritten methods.
`Backend wire contract`: verified against the live CloudWatch/ApplicationSignals API via SigV4 (create/list/report/delete round-trip, AWS x-amzn-RequestId on each response) and a mock-backend harness.
Results

Unit (net8.0): Failed: 0, Passed: 163, Skipped: 1,
Unit (net10.0):  Failed: 0, Passed: 163, Skipped: 1
Real-profiler E2E:    8/8 scenarios PASS (native ReJIT weave)
PROBE + BREAKPOINT:   PASS (PROBE=5, BREAKPOINT=3 hit-gated; OFF-baseline=0)

