### PR TITLE
fix: pass --framework to dotnet lambda package for multi-target project

### DIFF
--- a/sample-applications/lambda-test-apps/SimpleLambdaFunction/build-and-deploy.sh
+++ b/sample-applications/lambda-test-apps/SimpleLambdaFunction/build-and-deploy.sh
@@ -15,7 +15,7 @@ bash ./build.sh
 check_if_step_failed_and_exit "There was an error building AWS Otel DotNet, exiting"
 
 cd ./sample-applications/lambda-test-apps/SimpleLambdaFunction
-dotnet lambda package -pl ./src/SimpleLambdaFunction --framework net10.0
+dotnet lambda package -pl ./src/SimpleLambdaFunction --framework net8.0
 check_if_step_failed_and_exit "There was an error building the SimpleLambdaFunction, exiting"
 
 cd ./terraform/lambda

--- a/sample-applications/lambda-test-apps/SimpleLambdaFunction/build-and-deploy.sh
+++ b/sample-applications/lambda-test-apps/SimpleLambdaFunction/build-and-deploy.sh
@@ -15,7 +15,7 @@ bash ./build.sh
 check_if_step_failed_and_exit "There was an error building AWS Otel DotNet, exiting"
 
 cd ./sample-applications/lambda-test-apps/SimpleLambdaFunction
-dotnet lambda package -pl ./src/SimpleLambdaFunction
+dotnet lambda package -pl ./src/SimpleLambdaFunction --framework net10.0
 check_if_step_failed_and_exit "There was an error building the SimpleLambdaFunction, exiting"
 
 cd ./terraform/lambda


### PR DESCRIPTION
## Summary

- After PR #422 changed `SimpleLambdaFunction.csproj` from single-target (`net8.0`) to multi-target (`net8.0;net10.0`), `dotnet lambda package` can no longer infer the framework automatically and fails with: `Missing required parameter: --framework`
- This fix explicitly passes `--framework net10.0` to `build-and-deploy.sh` so the Lambda layer performance test workflow in [aws-application-signals-test-framework](https://github.com/aws-observability/aws-application-signals-test-framework) succeeds again

## Test plan

- [ ] Run the [DotNet Lambda Layer Performance Test](https://github.com/aws-observability/aws-application-signals-test-framework/actions/workflows/dotnet-lambda-layer-perf-test.yml) workflow with `ADOT-DotNet-Branch` set to `fix/lambda-package-framework-flag` and verify the build step passes