### PR TITLE
fix: pin EC2/ECS resource detectors to semconv v1.40.0 for cloud.region

### DIFF
--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -665,7 +665,7 @@ public class Plugin
         // The current version of the AWS Resource Detectors doesn't build the EKS and ECS resource detectors
         // for NETFRAMEWORK. More details are found here: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1177#discussion_r1193329666
         // We need to work with upstream to support these detectors for windows.
-        builder.AddAWSEC2Detector();
+        builder.AddAWSEC2Detector(opts => opts.SemanticConventionVersion = SemanticConventionVersion.V1_40_0);
 #if !NETFRAMEWORK
         builder
             .AddAWSEKSDetector()

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -667,11 +667,11 @@ public class Plugin
         // We need to work with upstream to support these detectors for windows.
         // TODO: Remove explicit SemanticConventionVersion once upstream is fixed:
         // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/4768
-        builder.AddAWSEC2Detector(opts => opts.SemanticConventionVersion = SemanticConventionVersion.V1_40_0);
+        builder.AddAWSEC2Detector(opts => opts.SemanticConventionVersion = global::OpenTelemetry.Resources.AWS.SemanticConventionVersion.V1_40_0);
 #if !NETFRAMEWORK
         builder
             .AddAWSEKSDetector()
-            .AddAWSECSDetector(opts => opts.SemanticConventionVersion = SemanticConventionVersion.V1_40_0);
+            .AddAWSECSDetector(opts => opts.SemanticConventionVersion = global::OpenTelemetry.Resources.AWS.SemanticConventionVersion.V1_40_0);
 #endif
 
         return builder;

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -665,11 +665,13 @@ public class Plugin
         // The current version of the AWS Resource Detectors doesn't build the EKS and ECS resource detectors
         // for NETFRAMEWORK. More details are found here: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1177#discussion_r1193329666
         // We need to work with upstream to support these detectors for windows.
+        // TODO: Remove explicit SemanticConventionVersion once upstream is fixed:
+        // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/4768
         builder.AddAWSEC2Detector(opts => opts.SemanticConventionVersion = SemanticConventionVersion.V1_40_0);
 #if !NETFRAMEWORK
         builder
             .AddAWSEKSDetector()
-            .AddAWSECSDetector();
+            .AddAWSECSDetector(opts => opts.SemanticConventionVersion = SemanticConventionVersion.V1_40_0);
 #endif
 
         return builder;


### PR DESCRIPTION
## Summary

- The upstream OpenTelemetry.Resources.AWS 1.16.0 update changed the default semantic convention version for the EC2 and ECS resource detectors, causing them to stop emitting `cloud.region`. This breaks the Application Signals E2E k8s test which validates that attribute in OTLP data sent to X-Ray.
- Pins `SemanticConventionVersion.V1_40_0` on `AddAWSEC2Detector` and `AddAWSECSDetector` to restore `cloud.region` emission.
- Uses `global::` qualifier to disambiguate from `OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion`.

Upstream tracking issue: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/4768

## Test plan

- [x] Local build passes (`dotnet build --framework net8.0`)
- [ ] Application Signals E2E k8s test passes with this fix (validates `cloud.region` present in OTLP resource attributes)