### PR TITLE
test(contract): strengthen AWS SDK attribute coverage ahead of v4 migration

### DIFF
--- a/test/contract-tests/tests/test/amazon/awssdk/awssdk_test.py
+++ b/test/contract-tests/tests/test/amazon/awssdk/awssdk_test.py
@@ -51,6 +51,12 @@ _GEN_AI_USAGE_OUTPUT_TOKENS: str = "gen_ai.usage.output_tokens"
 _GEN_AI_RESPONSE_FINISH_REASONS: str = "gen_ai.response.finish_reasons"
 _AWS_DYNAMODB_TABLE_ARN: str = "aws.dynamodb.table.arn"
 
+_AWS_REQUEST_ID: str = "aws.requestId"
+_HTTP_RESPONSE_CONTENT_LENGTH: str = "http.response_content_length"
+_AWS_AUTH_ACCOUNT_ACCESS_KEY: str = "aws.auth.account.access_key"
+_AWS_AUTH_REGION: str = "aws.auth.region"
+_DB_SYSTEM: str = "db.system"
+
 # pylint: disable=too-many-public-methods
 class AWSSdkTest(ContractTestBase):
     _local_stack: LocalStackContainer
@@ -178,6 +184,7 @@ class AWSSdkTest(ContractTestBase):
             request_response_specific_attributes={
                 # SpanAttributes.AWS_DYNAMODB_TABLE_NAMES: ["test_table"],
                 "aws.table_name": ["test_table"],
+                _DB_SYSTEM: "dynamodb",
             },
             span_name="DynamoDB.CreateTable",
         )
@@ -197,6 +204,7 @@ class AWSSdkTest(ContractTestBase):
             request_response_specific_attributes={
                 # SpanAttributes.AWS_DYNAMODB_TABLE_NAMES: ["test_table"],
                 "aws.table_name": ["test_table"],
+                _DB_SYSTEM: "dynamodb",
             },
             span_name="DynamoDB.PutItem",
         )
@@ -217,6 +225,7 @@ class AWSSdkTest(ContractTestBase):
             cloudformation_primary_identifier="test-table",
             request_response_specific_attributes={
                 "aws.table_name": ["test-table"],
+                _DB_SYSTEM: "dynamodb",
             },
             response_specific_attributes={
                 _AWS_DYNAMODB_TABLE_ARN: r"arn:aws:dynamodb:us-east-1:000000000000:table/test-table",
@@ -895,6 +904,9 @@ class AWSSdkTest(ContractTestBase):
             },
             remote_resource_access_key="account_b_access_key_id",
             remote_resource_region="eu-central-1",
+            # Assert the raw span-level credential attributes that the AppSignals attributes above derive from.
+            aws_auth_access_key="account_b_access_key_id",
+            aws_auth_region="eu-central-1",
             span_name="S3.PutBucket",
         )
 
@@ -969,6 +981,14 @@ class AWSSdkTest(ContractTestBase):
 
         self.assertEqual(len(target_spans), 1)
         self.assertEqual(target_spans[0].name, kwargs.get("span_name"))
+
+        # Assert the request-only, response-only, and combined request/response attribute maps together.
+        specific_attributes: dict = {
+            **kwargs.get("request_specific_attributes", {}),
+            **kwargs.get("response_specific_attributes", {}),
+            **kwargs.get("request_response_specific_attributes", {}),
+        }
+
         self._assert_semantic_conventions_attributes(
             target_spans[0].attributes,
             # For most cases, rpc_service is the same as the service name after "AWS::" prefix. Bedrock services are
@@ -977,7 +997,11 @@ class AWSSdkTest(ContractTestBase):
             kwargs.get("remote_service"),
             kwargs.get("remote_operation"),
             status_code,
-            kwargs.get("request_response_specific_attributes", {}),
+            specific_attributes,
+            # Forward only the keys used to assert the common per-call attributes.
+            aws_auth_access_key=kwargs.get("aws_auth_access_key"),
+            aws_auth_region=kwargs.get("aws_auth_region"),
+            assert_common_attributes=kwargs.get("assert_common_attributes"),
         )
 
     # pylint: disable=unidiomatic-typecheck
@@ -989,12 +1013,14 @@ class AWSSdkTest(ContractTestBase):
         operation: str,
         status_code: int,
         request_response_specific_attributes: dict,
+        **kwargs,
     ) -> None:
         attributes_dict: Dict[str, AnyValue] = self._get_attributes_dict(attributes_list)
         self._assert_str_attribute(attributes_dict, SpanAttributes.RPC_METHOD, operation)
         self._assert_str_attribute(attributes_dict, SpanAttributes.RPC_SYSTEM, "aws-api")
         self._assert_str_attribute(attributes_dict, SpanAttributes.RPC_SERVICE, rpc_service)
         self._assert_int_attribute(attributes_dict, SpanAttributes.HTTP_STATUS_CODE, status_code)
+        self._assert_common_aws_attributes(attributes_dict, service, status_code, **kwargs)
         for key, value in request_response_specific_attributes.items():
             if isinstance(value, str):
                 self._assert_str_attribute(attributes_dict, key, value)
@@ -1007,6 +1033,36 @@ class AWSSdkTest(ContractTestBase):
                 self._assert_invoke_model_finish_reasons(attributes_dict, key, value)
             else:
                 self._assert_array_value_ddb_table_name(attributes_dict, key, value)
+
+    def _assert_common_aws_attributes(
+        self, attributes_dict: Dict[str, AnyValue], service: str, status_code: int, **kwargs
+    ) -> None:
+        """Assert the common AWS SDK attributes emitted on every instrumented client span.
+
+        `aws.requestId` / `http.response_content_length` depend on a real HTTP response carrying a request-id
+        header and a content length, which the hand-mocked Bedrock endpoints do not, so these checks default
+        off for Bedrock services and on for real LocalStack-backed calls. A test may override with
+        assert_common_attributes=True/False; None uses the default.
+
+        `aws.region` is not asserted: the sample-app clients configure only ServiceURL, so it resolves to null
+        and the tag is omitted. Asserting it needs a client that resolves a concrete region (E2E follow-up).
+        """
+        assert_common = kwargs.get("assert_common_attributes")
+        if assert_common is None:
+            assert_common = "Bedrock" not in service
+        if assert_common:
+            self.assertIn(_AWS_REQUEST_ID, attributes_dict)
+            # http.response_content_length is only tagged when an HTTP response object exists (success path).
+            if status_code < 400:
+                self.assertIn(_HTTP_RESPONSE_CONTENT_LENGTH, attributes_dict)
+
+        # Credential-derived attributes, asserted for tests that configure explicit credentials.
+        expected_access_key = kwargs.get("aws_auth_access_key")
+        if expected_access_key is not None:
+            self._assert_str_attribute(attributes_dict, _AWS_AUTH_ACCOUNT_ACCESS_KEY, expected_access_key)
+        expected_auth_region = kwargs.get("aws_auth_region")
+        if expected_auth_region is not None:
+            self._assert_str_attribute(attributes_dict, _AWS_AUTH_REGION, expected_auth_region)
 
     @override
     def _assert_metric_attributes(


### PR DESCRIPTION
## Description

Strengthens the AWS SDK contract tests so a passing run reliably verifies the span attributes our instrumentation emits — both the **raw span attributes** and the **Application Signals attributes** derived from them. This lands ahead of the AWS SDK v3→v4 migration ([apm-telegen-3160](https://sim.amazon.com/issues/apm-telegen-3160)) so the suite can serve as a migration sanity check.

Investigation found the existing suite had real gaps precisely where the v4 migration is riskiest, and one latent harness bug that silently dropped assertions.

## Changes

- **Fix a latent harness gap:** `request_specific_attributes` and `response_specific_attributes` were passed by some tests (cross-account, DynamoDB `DescribeTable`) but never asserted at the span level — only `request_response_specific_attributes` was read. They are now merged and verified, which **activates the previously-dead `aws.dynamodb.table.arn` and `aws.s3.bucket` assertions**.
- **Credential-derived attributes:** assert `aws.auth.account.access_key` and `aws.auth.region` at the raw span level in the cross-account test (previously only checked indirectly at the metric layer). These are the riskiest part of the v4 migration since v4's `IRequestContext` no longer exposes `ImmutableCredentials` directly.
- **Common per-call attributes:** assert `aws.requestId` and `http.response_content_length` on real LocalStack-backed calls (skipped for the hand-mocked Bedrock endpoints whose responses omit `x-amzn-RequestId`).
- **`db.system=dynamodb`** on the DynamoDB tests.

## Known gaps (documented in code, tracked for follow-up)

- **`aws.region`** — sample-app clients configure only `ServiceURL` (a LocalStack host), so `DetermineRegion` returns null and the tag is omitted. Asserting it needs a client that resolves a concrete region.
- **Lambda** (`aws.lambda.function.name` / `.arn` / `resource_mapping.id`) — no sample-app infrastructure exists yet; deferred to a planned E2E test.

## Testing

- Python syntax compiles; `pylint` shows no new findings.
- Contract-test Docker suite (mock collector + LocalStack + sample app) to be run in CI.
