### PR TITLE
ci(release): sign the public ECR image and the Lambda layer

### DIFF
--- a/.github/workflows/region-build-release.yml
+++ b/.github/workflows/region-build-release.yml
@@ -110,12 +110,31 @@ jobs:
         with:
           name: ${{ env.LAYER_ARTIFACT_NAME }}
 
+      - name: Upload to S3 and Sign
+        continue-on-error: true
+        run: |
+          aws s3 mb s3://${{ env.BUCKET_NAME }}
+          aws s3 cp ${{ env.LAYER_ARTIFACT_NAME }} s3://${{ env.BUCKET_NAME }}
+
+          # Sign the layer
+          PROFILE=$(aws signer list-signing-profiles --query "profiles[?profileName=='ADOTLambdaLayerSigningProfile'].arn" --output text 2>/dev/null)
+          [ -z "$PROFILE" ] && echo "No signing profile found, skipping" && exit 0
+
+          JOB_ID=$(aws signer start-signing-job \
+            --source "s3={bucketName=${{ env.BUCKET_NAME }},key=${{ env.LAYER_ARTIFACT_NAME }},version=null}" \
+            --destination "s3={bucketName=${{ env.BUCKET_NAME }},prefix=signed-}" \
+            --profile-name ADOTLambdaLayerSigningProfile \
+            --query 'jobId' --output text)
+
+          aws signer wait successful-signing-job --job-id "$JOB_ID"
+
+          SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text)
+          aws s3 rm "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
+          aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
       - name: Publish Lambda layer version
         env:
           VERSION: ${{ env.VERSION_INPUT }}
         run: |
-          aws s3 mb s3://${{ env.BUCKET_NAME }}
-          aws s3 cp ${{ env.LAYER_ARTIFACT_NAME }} s3://${{ env.BUCKET_NAME }}
           layerARN=$(
             aws lambda publish-layer-version \
               --layer-name ${{ env.LAYER_NAME }} \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -307,12 +307,31 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
+      - name: Upload to S3 and Sign
+        continue-on-error: true
+        run: |
+          aws s3 mb s3://${{ env.BUCKET_NAME }}
+          aws s3 cp aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip s3://${{ env.BUCKET_NAME }}
+
+          # Sign the layer
+          PROFILE=$(aws signer list-signing-profiles --query "profiles[?profileName=='ADOTLambdaLayerSigningProfile'].arn" --output text 2>/dev/null)
+          [ -z "$PROFILE" ] && echo "No signing profile found, skipping" && exit 0
+
+          JOB_ID=$(aws signer start-signing-job \
+            --source "s3={bucketName=${{ env.BUCKET_NAME }},key=aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip,version=null}" \
+            --destination "s3={bucketName=${{ env.BUCKET_NAME }},prefix=signed-}" \
+            --profile-name ADOTLambdaLayerSigningProfile \
+            --query 'jobId' --output text)
+
+          aws signer wait successful-signing-job --job-id "$JOB_ID"
+
+          SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text)
+          aws s3 rm "s3://${{ env.BUCKET_NAME }}/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip"
+          aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip"
       - name: publish
         env:
           VERSION: ${{ env.VERSION_INPUT }}
         run: |
-          aws s3 mb s3://${{ env.BUCKET_NAME }}
-          aws s3 cp aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip s3://${{ env.BUCKET_NAME }}
           layerARN=$(
             aws lambda publish-layer-version \
               --layer-name ${{ env.LAYER_NAME }} \
@@ -573,3 +592,68 @@ jobs:
             layer.zip \
             layer.zip.sha256 \
             --clobber
+
+  sign-public-ecr-image:
+    runs-on: ubuntu-latest
+    needs: publish-github
+    steps:
+      - name: Configure AWS Credentials for public ECR
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
+          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
+
+      # Install notation CLI with AWS Signer plugin
+      - name: Install notation CLI with AWS Signer plugin
+        continue-on-error: true
+        run: |
+          curl -Lo aws-signer-notation-cli_amd64.deb https://d2hvyiie56hcat.cloudfront.net/linux/amd64/installer/deb/latest/aws-signer-notation-cli_amd64.deb
+          sudo dpkg -i aws-signer-notation-cli_amd64.deb
+          notation version
+          notation plugin ls
+
+      # Query ECR signing profile ARN
+      - name: Query ECR Signing Profile ARN
+        id: ecr-signing-profile
+        continue-on-error: true
+        run: |
+          PROFILE_ARN=$(aws signer get-signing-profile --region ${{ env.AWS_PUBLIC_ECR_REGION }} --profile-name ADOTECRSigningProfile --query "arn" --output text) || PROFILE_ARN=""
+          if [ -n "$PROFILE_ARN" ] && [ "$PROFILE_ARN" != "None" ]; then
+            echo "profile_arn=$PROFILE_ARN" >> $GITHUB_OUTPUT
+            echo "Found ECR signing profile: $PROFILE_ARN"
+          else
+            echo "ECR signing profile 'ADOTECRSigningProfile' not found or lookup failed; skipping image signing."
+            exit 0
+          fi
+
+      # Login to Public ECR
+      - name: Log in to AWS public ECR
+        if: steps.ecr-signing-profile.outputs.profile_arn != ''
+        continue-on-error: true
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: public.ecr.aws
+
+      # Sign Public ECR Image
+      - name: Sign Public ECR Image
+        if: steps.ecr-signing-profile.outputs.profile_arn != ''
+        continue-on-error: true
+        env:
+          VERSION: ${{ env.VERSION_INPUT }}
+        run: |
+          # notation needs a digest ref to store the signature via the Referrers API,
+          # which avoids publishing the extra "sha256-<digest>" fallback tag.
+          DIGEST=$(aws ecr-public describe-image-tags \
+            --repository-name adot-autoinstrumentation-dotnet \
+            --region ${{ env.AWS_PUBLIC_ECR_REGION }} \
+            --query "imageTagDetails[?imageTag=='v$VERSION'].imageDetail.imageDigest | [0]" \
+            --output text)
+          if [ -z "$DIGEST" ] || [ "$DIGEST" = "None" ]; then
+            echo "Could not resolve a digest for v$VERSION; skipping image signing."
+            exit 0
+          fi
+          notation sign ${{ env.RELEASE_PUBLIC_REPOSITORY }}@${DIGEST} \
+            --force-referrers-tag=false \
+            --plugin com.amazonaws.signer.notation.plugin \
+            --id ${{ steps.ecr-signing-profile.outputs.profile_arn }}


### PR DESCRIPTION
## Description

Adds artifact signing to the .NET distro release, bringing it in line with the Python distro. Two independent, best-effort additions:

### 1. Sign the public ECR image
A new \`sign-public-ecr-image\` job runs **last** (after \`publish-github\`) and signs the released \`public.ecr.aws/aws-observability/adot-autoinstrumentation-dotnet\` image using the AWS Signer notation plugin.

- Signs by **digest** with \`--force-referrers-tag=false\`, so the signature is stored via the OCI Referrers API and **no extra \`sha256-<digest>\` fallback tag** is published to the ECR gallery (which users see).
- The signing profile ARN is resolved with \`signer:get-signing-profile\` (least privilege, ARN-scoped) rather than \`list-signing-profiles\`.
- Every step is \`continue-on-error: true\`, so a signing failure never fails the release run or affects already-published artifacts.

### 2. Sign the Lambda layer
In both \`release-build.yml\` and \`region-build-release.yml\`, the layer is now signed before \`publish-layer-version\`. A new \`Upload to S3 and Sign\` step uploads the layer zip, runs an AWS Signer signing job with \`ADOTLambdaLayerSigningProfile\`, and overwrites the uploaded object with the signed one. The step is \`continue-on-error\` and skips cleanly (\`No signing profile found, skipping\`) when no profile is available.

## Testing

- ECR signing approach (digest ref + \`--force-referrers-tag=false\`) was verified end-to-end in a personal AWS account: the signature is discoverable via the Referrers API and no fallback tag is created.
- Lambda layer signing mirrors the working Python distro step.

> Note: both features require the corresponding release roles to have the AWS Signer permissions and the signing profiles (\`ADOTECRSigningProfile\`, \`ADOTLambdaLayerSigningProfile\`) to exist; otherwise the steps skip without failing the release.