### PR TITLE
Set max supported AWS SDK version to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ For any change that affects end users of this package, please add an entry under
 If your change does not need a CHANGELOG entry, add the "skip changelog" label to your PR.
 
 ## Unreleased
+- Cap `AWSSDK.Core` and `AWSSDK.XRay` dependencies below `4.0.0`. This release line targets AWS SDK
+  for .NET v3 and is binary-incompatible with v4, so a v3-ADOT + v4-AWSSDK combination now surfaces
+  an explicit NuGet resolution conflict (NU1107) at restore instead of silently co-resolving a
+  mismatched AWS SDK that can fail at runtime. Users on AWS SDK v4 should upgrade to the ADOT release
+  that adds v4 support.
+  ([#TBD](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/TBD))
 
 ## v1.14.0 - 2026-07-15
 - Fix Linux arm64 image being built with the x64 payload, which caused the shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,8 @@ For any change that affects end users of this package, please add an entry under
 If your change does not need a CHANGELOG entry, add the "skip changelog" label to your PR.
 
 ## Unreleased
-- Cap `AWSSDK.Core` and `AWSSDK.XRay` dependencies below `4.0.0`. This release line targets AWS SDK
-  for .NET v3 and is binary-incompatible with v4, so a v3-ADOT + v4-AWSSDK combination now surfaces
-  an explicit NuGet resolution conflict (NU1107) at restore instead of silently co-resolving a
-  mismatched AWS SDK that can fail at runtime. Users on AWS SDK v4 should upgrade to the ADOT release
-  that adds v4 support.
-  ([#TBD](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/TBD))
+- Update AWSSDK package references to indicate that this release is not compatible with AWS SDK v4.
+  ([#438](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/438))
 
 ## v1.14.0 - 2026-07-15
 - Fix Linux arm64 image being built with the x64 payload, which caused the shared

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
@@ -21,8 +21,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.XRay" Version="3.7.300" />
+    <!-- Cap AWSSDK below v4: this release targets AWS SDK for .NET v3 and is binary-incompatible
+         with v4. The upper bound makes a v3-ADOT + v4-AWSSDK combination an explicit NuGet
+         resolution conflict (NU1107) rather than a silent version co-resolution that fails at
+         runtime. Users on AWS SDK v4 should upgrade to the ADOT release that supports v4. -->
+    <PackageReference Include="AWSSDK.Core" Version="[3.7.400, 4.0.0)" />
+    <PackageReference Include="AWSSDK.XRay" Version="[3.7.300, 4.0.0)" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AWS.Distro.OpenTelemetry.AutoInstrumentation.csproj
@@ -21,10 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net462'" />
-    <!-- Cap AWSSDK below v4: this release targets AWS SDK for .NET v3 and is binary-incompatible
-         with v4. The upper bound makes a v3-ADOT + v4-AWSSDK combination an explicit NuGet
-         resolution conflict (NU1107) rather than a silent version co-resolution that fails at
-         runtime. Users on AWS SDK v4 should upgrade to the ADOT release that supports v4. -->
     <PackageReference Include="AWSSDK.Core" Version="[3.7.400, 4.0.0)" />
     <PackageReference Include="AWSSDK.XRay" Version="[3.7.300, 4.0.0)" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.4" />


### PR DESCRIPTION
Cap `AWSSDK.Core` and `AWSSDK.XRay` package references below `4.0.0` to indicate that this release line is not compatible with AWS SDK for .NET v4.

## Changes

Set the max supported AWS SDK version to v3 on the `release/v1.14.x` line.