### PR TITLE
feat(app-signals): attribute presigned S3 URLs for raw HTTP calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For any change that affects end users of this package, please add an entry under
 If your change does not need a CHANGELOG entry, add the "skip changelog" label to your PR.
 
 ## Unreleased
+- Attribute presigned S3 URLs as `AWS::S3` dependencies in Application Signals, opt-in via
+  `OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED`
+  ([#440](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/440))
+
 - Add adaptive sampling support for anomaly detection and trace capture
   ([#410](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/410))
 

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
@@ -61,6 +61,13 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
     // Special DEPENDENCY attribute value if GRAPHQL_OPERATION_TYPE attribute key is present.
     private static readonly string GraphQL = "graphql";
 
+    // Opt-in flag (default off) for attributing raw-HTTP presigned S3 URL calls as AWS::S3
+    // dependencies instead of generic HTTP calls. Read at call time rather than cached in a
+    // constructor because the generator is created as a static singleton (see
+    // AwsSpanMetricsProcessorBuilder / AwsMetricAttributesSpanProcessorBuilder) before the SDK reads
+    // environment configuration.
+    private static readonly string PresignedUrlAttributionEnabledConfig = "OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED";
+
     /// <inheritdoc/>
     public virtual Dictionary<string, ActivityTagsCollection> GenerateMetricAttributeMapFromSpan(Activity span, Resource resource)
     {
@@ -94,8 +101,8 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
         SetService(resource, span, attributes);
         SetEgressOperation(span, attributes);
         SetRemoteEnvironment(span, attributes);
-        SetRemoteServiceAndOperation(span, attributes);
-        bool isRemoteResourceIdentifierPresent = SetRemoteResourceTypeAndIdentifier(span, attributes);
+        PresignedUrlAttribution? presignedAttribution = SetRemoteServiceAndOperation(span, attributes);
+        bool isRemoteResourceIdentifierPresent = SetRemoteResourceTypeAndIdentifier(span, attributes, presignedAttribution);
         if (isRemoteResourceIdentifierPresent)
         {
             bool isAccountIdAndRegionPresent = SetRemoteResourceAccountIdAndRegion(span, attributes);
@@ -198,10 +205,11 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
     /// `net.peer.sock.port` and `http.url` will be used to derive the RemoteService. And `http.method`
     /// and `http.url` will be used to derive the RemoteOperation.
     /// </summary>
-    private static void SetRemoteServiceAndOperation(Activity span, ActivityTagsCollection attributes)
+    private static PresignedUrlAttribution? SetRemoteServiceAndOperation(Activity span, ActivityTagsCollection attributes)
     {
         string remoteService = UnknownRemoteService;
         string remoteOperation = UnknownRemoteOperation;
+        PresignedUrlAttribution? presignedAttribution = null;
         if (IsKeyPresent(span, AttributeAWSRemoteService) || IsKeyPresent(span, AttributeAWSRemoteOperation))
         {
             remoteService = GetRemoteService(span, AttributeAWSRemoteService);
@@ -248,6 +256,18 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
             remoteService = GraphQL;
             remoteOperation = GetRemoteOperation(span, AttributeGraphqlOperationType);
         }
+        else if (IsPresignedUrlAttributionEnabled() && !IsAwsSDKSpan(span))
+        {
+            // Fallback for raw HTTP calls using a presigned URL. Exclude AWS SDK spans explicitly:
+            // they use the SDK attribution path even when their RPC service or method attributes are
+            // absent. Parse the URL only when we reach this branch.
+            presignedAttribution = PresignedUrlAttributor.Attribute(span);
+            if (presignedAttribution != null)
+            {
+                remoteService = presignedAttribution.RemoteService;
+                remoteOperation = presignedAttribution.RemoteOperation;
+            }
+        }
 
         // Peer service takes priority as RemoteService over everything but AWS Remote.
         if (IsKeyPresent(span, AttributePeerService) && !IsKeyPresent(span, AttributeAWSRemoteService))
@@ -261,13 +281,24 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
             remoteService = GenerateRemoteService(span);
         }
 
-        if (remoteOperation.Equals(UnknownRemoteOperation))
+        // When a presigned AWS URL was attributed, keep its remote operation as-is. Resolvers
+        // intentionally return UnknownRemoteOperation for ambiguous calls (e.g. a bucket-level S3
+        // GET), and falling back to the generic HTTP path here would reintroduce the
+        // high-cardinality "GET /<key>" operation this feature is meant to avoid.
+        if (remoteOperation.Equals(UnknownRemoteOperation) && presignedAttribution == null)
         {
             remoteOperation = GenerateRemoteOperation(span);
         }
 
         attributes.Add(AttributeAWSRemoteService, remoteService);
         attributes.Add(AttributeAWSRemoteOperation, remoteOperation);
+        return presignedAttribution;
+    }
+
+    // Whether presigned AWS URL attribution is enabled via the opt-in environment flag.
+    private static bool IsPresignedUrlAttributionEnabled()
+    {
+        return System.Environment.GetEnvironmentVariable(PresignedUrlAttributionEnabledConfig) == "true";
     }
 
     // When the remote call operation is undetermined for http use cases,
@@ -425,7 +456,7 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
     // and RemoteResourceIdentifier accordingly. Right now, this sets it for DDB, S3, Kinesis,
     // and SQS (using QueueName or QueueURL). Returns true if remote resource type and identifier
     // are successfully set, false otherwise.
-    private static bool SetRemoteResourceTypeAndIdentifier(Activity span, ActivityTagsCollection attributes)
+    private static bool SetRemoteResourceTypeAndIdentifier(Activity span, ActivityTagsCollection attributes, PresignedUrlAttribution? presignedAttribution)
     {
         string? remoteResourceType = null;
         string? remoteResourceIdentifier = null;
@@ -541,6 +572,15 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
             {
                 remoteResourceType = NormalizedBedrockServiceName + "::KnowledgeBase";
                 remoteResourceIdentifier = EscapeDelimiters((string?)span.GetTagItem(AttributeAWSBedrockKnowledgeBaseId));
+            }
+        }
+        else if (presignedAttribution != null)
+        {
+            RemoteResource? remoteResource = presignedAttribution.RemoteResource;
+            if (remoteResource != null)
+            {
+                remoteResourceType = remoteResource.Type;
+                remoteResourceIdentifier = EscapeDelimiters(remoteResource.Identifier);
             }
         }
         else if (IsDBSpan(span))

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsMetricAttributeGenerator.cs
@@ -61,10 +61,8 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
     // Special DEPENDENCY attribute value if GRAPHQL_OPERATION_TYPE attribute key is present.
     private static readonly string GraphQL = "graphql";
 
-    // Opt-in flag (default off) for attributing raw-HTTP presigned S3 URL calls as AWS::S3
-    // dependencies instead of generic HTTP calls. Read at call time rather than cached in a
-    // constructor because the generator is created as a static singleton (see
-    // AwsSpanMetricsProcessorBuilder / AwsMetricAttributesSpanProcessorBuilder) before the SDK reads
+    // Opt-in flag (default off) for attributing presigned S3 URL calls as AWS::S3 dependencies. Read
+    // at call time because the generator is constructed as a static singleton before the SDK reads
     // environment configuration.
     private static readonly string PresignedUrlAttributionEnabledConfig = "OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED";
 
@@ -295,7 +293,6 @@ internal class AwsMetricAttributeGenerator : IMetricAttributeGenerator
         return presignedAttribution;
     }
 
-    // Whether presigned AWS URL attribution is enabled via the opt-in environment flag.
     private static bool IsPresignedUrlAttributionEnabled()
     {
         return System.Environment.GetEnvironmentVariable(PresignedUrlAttributionEnabledConfig) == "true";

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrl.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrl.cs
@@ -45,10 +45,6 @@ internal sealed class PresignedAwsUrl
     }
 
     // Returns the first value for a query parameter, or null when the parameter is absent.
-    //
-    // Note: under .NET's URL sanitization every query value is replaced with the literal "Redacted",
-    // so callers must treat a returned value as an opaque presence signal only. Operations are keyed
-    // on the presence of the parameter, never on its value. See S3PresignedUrlAttributor.
     internal string? GetFirstQueryParameterValue(string name)
     {
         if (this.queryParameters.TryGetValue(name, out List<string>? values) && values.Count > 0)
@@ -59,8 +55,7 @@ internal sealed class PresignedAwsUrl
         return null;
     }
 
-    // Whether a query parameter is present, regardless of its value. This is the primary signal used
-    // for operation resolution because sanitization strips query values.
+    // Whether a query parameter is present, regardless of its value.
     internal bool HasQueryParameter(string name)
     {
         return this.queryParameters.ContainsKey(name);

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrl.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrl.cs
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// A parsed SigV4 presigned AWS URL.
+///
+/// <para>Carries the request context needed for attribution that a plain parsed URL cannot express:
+/// the HTTP method (which comes from the span, not the URL) and the parsed query parameters. The
+/// host and path come from the URL itself.</para>
+///
+/// <para>The signing service is intentionally not carried here: it is derived from the SigV4
+/// credential scope, which URL sanitization redacts. Service identity is instead determined from the
+/// endpoint hostname by the service-specific attributor.</para>
+/// </summary>
+internal sealed class PresignedAwsUrl
+{
+    private readonly string host;
+    private readonly string path;
+    private readonly string? httpMethod;
+    private readonly IReadOnlyDictionary<string, List<string>> queryParameters;
+
+    internal PresignedAwsUrl(string host, string path, string? httpMethod, IReadOnlyDictionary<string, List<string>> queryParameters)
+    {
+        this.host = host;
+        this.path = string.IsNullOrEmpty(path) ? "/" : path;
+        this.httpMethod = httpMethod;
+        this.queryParameters = queryParameters;
+    }
+
+    internal string? GetHttpMethod()
+    {
+        return this.httpMethod;
+    }
+
+    internal string GetHost()
+    {
+        return this.host;
+    }
+
+    internal string GetPath()
+    {
+        return this.path;
+    }
+
+    // Returns the first value for a query parameter, or null when the parameter is absent.
+    //
+    // Note: under .NET's URL sanitization every query value is replaced with the literal "Redacted",
+    // so callers must treat a returned value as an opaque presence signal only. Operations are keyed
+    // on the presence of the parameter, never on its value. See S3PresignedUrlAttributor.
+    internal string? GetFirstQueryParameterValue(string name)
+    {
+        if (this.queryParameters.TryGetValue(name, out List<string>? values) && values.Count > 0)
+        {
+            return values[0];
+        }
+
+        return null;
+    }
+
+    // Whether a query parameter is present, regardless of its value. This is the primary signal used
+    // for operation resolution because sanitization strips query values.
+    internal bool HasQueryParameter(string name)
+    {
+        return this.queryParameters.ContainsKey(name);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrlParser.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrlParser.cs
@@ -10,21 +10,13 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
 /// <summary>
 /// Recognizes a SigV4/SigV4a presigned AWS URL from a span's URL.
 ///
-/// <para>Detection relies only on the presence of the six SigV4 query-string parameters that a
-/// presigned (query-authenticated) request always carries: <c>X-Amz-Algorithm</c>,
-/// <c>X-Amz-Credential</c>, <c>X-Amz-Signature</c>, <c>X-Amz-Date</c>, <c>X-Amz-Expires</c>, and
-/// <c>X-Amz-SignedHeaders</c>. Their co-occurrence — anchored by <c>X-Amz-Expires</c>, which is
-/// specific to presigned URLs — is a high-specificity fingerprint.</para>
-///
-/// <para><b>.NET-specific divergence from the Java/Python/JS ports:</b> those parsers additionally
-/// check the <c>X-Amz-Algorithm</c> value against a SigV4 algorithm allowlist and require the other
-/// parameters to be non-empty. This distro's URL sanitization (see
-/// <c>OpenTelemetry.Internal.RedactionHelper.GetRedactedQueryString</c>) blanks <b>every</b> query
-/// value to the literal <c>Redacted</c> before metric attribution runs — even a value that was
-/// originally empty becomes <c>Redacted</c>. So no query value can be read here: detection and
-/// operation resolution key on parameter <b>presence</b> only. Dropping the algorithm allowlist is
-/// safe because nothing downstream branches on SigV4 vs SigV4a — the signing service is derived from
-/// the endpoint hostname, not the credential scope.</para>
+/// <para>Detection relies on the presence of the six SigV4 query-string parameters that a presigned
+/// (query-authenticated) request always carries: <c>X-Amz-Algorithm</c>, <c>X-Amz-Credential</c>,
+/// <c>X-Amz-Signature</c>, <c>X-Amz-Date</c>, <c>X-Amz-Expires</c>, and <c>X-Amz-SignedHeaders</c>.
+/// Only presence is checked, not the values: this distro's URL sanitization
+/// (<c>OpenTelemetry.Internal.RedactionHelper.GetRedactedQueryString</c>) blanks every query value to
+/// the literal <c>Redacted</c> before metric attribution runs, so no query value can be read here.
+/// The signing service is identified downstream from the endpoint hostname, not the credential scope.</para>
 ///
 /// <para>Query-string (presigned) SigV4 authentication parameters are defined here:
 /// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html. Per

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrlParser.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedAwsUrlParser.cs
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsSpanProcessingUtil;
+using static OpenTelemetry.Trace.TraceSemanticConventions;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// Recognizes a SigV4/SigV4a presigned AWS URL from a span's URL.
+///
+/// <para>Detection relies only on the presence of the six SigV4 query-string parameters that a
+/// presigned (query-authenticated) request always carries: <c>X-Amz-Algorithm</c>,
+/// <c>X-Amz-Credential</c>, <c>X-Amz-Signature</c>, <c>X-Amz-Date</c>, <c>X-Amz-Expires</c>, and
+/// <c>X-Amz-SignedHeaders</c>. Their co-occurrence — anchored by <c>X-Amz-Expires</c>, which is
+/// specific to presigned URLs — is a high-specificity fingerprint.</para>
+///
+/// <para><b>.NET-specific divergence from the Java/Python/JS ports:</b> those parsers additionally
+/// check the <c>X-Amz-Algorithm</c> value against a SigV4 algorithm allowlist and require the other
+/// parameters to be non-empty. This distro's URL sanitization (see
+/// <c>OpenTelemetry.Internal.RedactionHelper.GetRedactedQueryString</c>) blanks <b>every</b> query
+/// value to the literal <c>Redacted</c> before metric attribution runs — even a value that was
+/// originally empty becomes <c>Redacted</c>. So no query value can be read here: detection and
+/// operation resolution key on parameter <b>presence</b> only. Dropping the algorithm allowlist is
+/// safe because nothing downstream branches on SigV4 vs SigV4a — the signing service is derived from
+/// the endpoint hostname, not the credential scope.</para>
+///
+/// <para>Query-string (presigned) SigV4 authentication parameters are defined here:
+/// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html. Per
+/// https://docs.aws.amazon.com/prescriptive-guidance/latest/presigned-url-best-practices/overview.html,
+/// the <c>X-Amz-Expires</c> parameter is what distinguishes a presigned URL from other signed
+/// requests.</para>
+/// </summary>
+internal sealed class PresignedAwsUrlParser
+{
+    private const string XAmzAlgorithm = "X-Amz-Algorithm";
+    private const string XAmzCredential = "X-Amz-Credential";
+    private const string XAmzSignature = "X-Amz-Signature";
+    private const string XAmzDate = "X-Amz-Date";
+    private const string XAmzExpires = "X-Amz-Expires";
+    private const string XAmzSignedHeaders = "X-Amz-SignedHeaders";
+
+    private PresignedAwsUrlParser()
+    {
+    }
+
+    // Parses the span's URL/method attributes (stable keys first, then legacy) into a
+    // PresignedAwsUrl, or null when the span does not carry a recognizable presigned URL.
+    internal static PresignedAwsUrl? Parse(Activity span)
+    {
+        // URL: stable `url.full` first, then legacy `http.url`.
+        string? url = (string?)span.GetTagItem(AttributeUrlFull) ?? (string?)span.GetTagItem(AttributeHttpUrl);
+
+        // Method: stable `http.request.method` first, then legacy `http.method`.
+        string? httpMethod = (string?)span.GetTagItem(AttributeHttpRequestMethod) ?? (string?)span.GetTagItem(AttributeHttpMethod);
+        return Parse(url, httpMethod);
+    }
+
+    internal static PresignedAwsUrl? Parse(string? url, string? httpMethod)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        Uri uri;
+        try
+        {
+            uri = new Uri(url!);
+        }
+        catch (UriFormatException)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(uri.Host))
+        {
+            return null;
+        }
+
+        // Uri.Query includes the leading '?'; strip it before splitting on '&'.
+        IReadOnlyDictionary<string, List<string>> queryParameters = ParseQueryParameters(uri.Query.TrimStart('?'));
+        if (!IsPresignedSigV4Request(queryParameters))
+        {
+            return null;
+        }
+
+        // Use AbsolutePath (not the raw query) so operation/bucket resolution sees only the path.
+        return new PresignedAwsUrl(uri.Host, uri.AbsolutePath, httpMethod, queryParameters);
+    }
+
+    /// <summary>
+    /// A request is a presigned SigV4/SigV4a request when it carries all six SigV4 query parameters.
+    /// Only presence is checked — see the class remarks for why values are unavailable in this distro.
+    /// </summary>
+    private static bool IsPresignedSigV4Request(IReadOnlyDictionary<string, List<string>> queryParameters)
+    {
+        return queryParameters.ContainsKey(XAmzAlgorithm)
+            && queryParameters.ContainsKey(XAmzCredential)
+            && queryParameters.ContainsKey(XAmzSignature)
+            && queryParameters.ContainsKey(XAmzDate)
+            && queryParameters.ContainsKey(XAmzExpires)
+            && queryParameters.ContainsKey(XAmzSignedHeaders);
+    }
+
+    private static IReadOnlyDictionary<string, List<string>> ParseQueryParameters(string rawQuery)
+    {
+        Dictionary<string, List<string>> queryParameters = new Dictionary<string, List<string>>();
+        if (string.IsNullOrEmpty(rawQuery))
+        {
+            return queryParameters;
+        }
+
+        foreach (string pair in rawQuery.Split('&'))
+        {
+            int delimiterIndex = pair.IndexOf('=');
+            string name = delimiterIndex >= 0 ? pair.Substring(0, delimiterIndex) : pair;
+            string value = delimiterIndex >= 0 ? pair.Substring(delimiterIndex + 1) : string.Empty;
+            string decodedName = Decode(name);
+            if (!queryParameters.TryGetValue(decodedName, out List<string>? values))
+            {
+                values = new List<string>();
+                queryParameters[decodedName] = values;
+            }
+
+            values.Add(Decode(value));
+        }
+
+        return queryParameters;
+    }
+
+    private static string Decode(string value)
+    {
+        try
+        {
+            return Uri.UnescapeDataString(value);
+        }
+        catch (Exception)
+        {
+            // Malformed percent-encoding; keep the raw value rather than dropping the parameter, so
+            // the presence-based checks still see it.
+            return value;
+        }
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedUrlAttribution.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedUrlAttribution.cs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// The Application Signals remote attribution derived from a presigned AWS URL. A resource is
+/// present only when the service-specific attributor can identify it confidently.
+/// </summary>
+internal sealed class PresignedUrlAttribution
+{
+    internal PresignedUrlAttribution(string remoteService, string remoteOperation, RemoteResource? remoteResource)
+    {
+        this.RemoteService = remoteService;
+        this.RemoteOperation = remoteOperation;
+        this.RemoteResource = remoteResource;
+    }
+
+    internal string RemoteService { get; }
+
+    internal string RemoteOperation { get; }
+
+    internal RemoteResource? RemoteResource { get; }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedUrlAttributor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/PresignedUrlAttributor.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// Derives Application Signals attribution from a presigned AWS URL. Parses the span's URL once,
+/// then lets each service-specific attributor try to claim it based on the endpoint hostname (the
+/// signing service cannot be read from the credential scope because it is redacted). If none claims
+/// the URL — custom CNAMEs, unknown endpoints, or non-presigned URLs — attribution falls back to the
+/// existing behavior.
+/// </summary>
+internal sealed class PresignedUrlAttributor
+{
+    private PresignedUrlAttributor()
+    {
+    }
+
+    internal static PresignedUrlAttribution? Attribute(Activity span)
+    {
+        PresignedAwsUrl? presignedAwsUrl = PresignedAwsUrlParser.Parse(span);
+        if (presignedAwsUrl == null)
+        {
+            return null;
+        }
+
+        return Attribute(presignedAwsUrl);
+    }
+
+    private static PresignedUrlAttribution? Attribute(PresignedAwsUrl presignedAwsUrl)
+    {
+        // Only S3 is supported today. Additional services (e.g. SQS, execute-api) can be tried here
+        // in turn, each claiming the URL only when it recognizes the endpoint.
+        return S3PresignedUrlAttributor.Attribute(presignedAwsUrl);
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/RemoteResource.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/RemoteResource.cs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// A remote resource (type and identifier) identified from a presigned AWS URL, e.g. an S3 bucket.
+/// </summary>
+internal sealed class RemoteResource
+{
+    internal RemoteResource(string type, string identifier)
+    {
+        this.Type = type;
+        this.Identifier = identifier;
+    }
+
+    internal string Type { get; }
+
+    internal string Identifier { get; }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/S3PresignedUrlAttributor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/S3PresignedUrlAttributor.cs
@@ -1,0 +1,303 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.RegularExpressions;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsSpanProcessingUtil;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
+
+/// <summary>
+/// Derives <c>AWS::S3</c> attribution from a presigned S3 URL by recognizing S3 endpoint hostnames.
+///
+/// <para>Because the signing service cannot be read from the (redacted) credential scope, S3 is
+/// identified purely from the endpoint host. Only the standard virtual-hosted and path-style S3
+/// endpoint forms are recognized. Anything else — custom CNAMEs, access points, unknown endpoints —
+/// fails closed (returns null) so we never mis-attribute a non-S3 or unverifiable request.</para>
+///
+/// <para>The remote operation is derived from the HTTP method, whether an object key is present
+/// (bucket- vs object-level), and the S3 subresource/multipart query parameters. Operation names
+/// follow the S3 REST API.</para>
+///
+/// <para><b>.NET-specific divergence:</b> the Java/Python/JS ports read the <c>list-type</c> value to
+/// confirm it equals <c>2</c> before mapping a bucket-level GET to <c>ListObjectsV2</c>. This distro's
+/// URL sanitization blanks every query value (see PresignedAwsUrlParser remarks), so the value is
+/// unavailable — this port keys on the <b>presence</b> of the <c>list-type</c> parameter instead. That
+/// is safe because <c>list-type</c> is unique to ListObjectsV2 in the S3 REST API (its only defined
+/// value is <c>2</c>, and no other operation uses the parameter), so its presence alone is an
+/// unambiguous marker. All other operation markers are valueless flags (e.g. <c>acl</c>,
+/// <c>tagging</c>, <c>uploads</c>) or presence-only keys (<c>uploadId</c>, <c>partNumber</c>), which
+/// survive sanitization intact.</para>
+///
+/// <para>References:
+/// <list type="bullet">
+///   <item>Endpoints: https://docs.aws.amazon.com/general/latest/gr/s3.html</item>
+///   <item>Virtual-hosted vs path-style: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html</item>
+///   <item>S3 REST API operations: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations.html</item>
+/// </list></para>
+/// </summary>
+internal sealed class S3PresignedUrlAttributor
+{
+    private const string NormalizedS3ServiceName = "AWS::S3";
+    private const string S3BucketResourceType = NormalizedS3ServiceName + "::Bucket";
+
+    // Standard S3 endpoint host forms, including global, regional, legacy regional, dual-stack,
+    // transfer acceleration, FIPS (incl. FIPS dual-stack), and China (.com.cn). The optional segment
+    // after "s3" covers the mutually exclusive endpoint styles.
+    //
+    // The legacy "-<label>" alternative is intentionally broad: besides legacy regional hosts
+    // (s3-us-west-2) it also matches other s3-prefixed AWS hosts such as s3-website-<region>. This is
+    // accepted deliberately as low risk — all such hosts are S3-owned domains anchored to
+    // amazonaws.com, and presigned object requests do not target website/other endpoints.
+    // https://docs.aws.amazon.com/general/latest/gr/s3.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html
+    private const string S3EndpointSuffix =
+        "s3(?:" +
+        @"\.(?:dualstack\.)?[a-z0-9-]+" + // s3.<region> | s3.dualstack.<region>
+        @"|-fips(?:\.dualstack)?\.[a-z0-9-]+" + // s3-fips.<region> | s3-fips.dualstack.<region>
+        @"|-accelerate(?:\.dualstack)?" + // s3-accelerate | s3-accelerate.dualstack
+        "|-[a-z0-9-]+" + // s3-<region> (legacy regional)
+        @")?\.amazonaws\.com(?:\.cn)?";
+
+    private static readonly Regex VirtualHostedS3Endpoint =
+        new Regex("^(.+)\\." + S3EndpointSuffix + "$", RegexOptions.IgnoreCase);
+
+    private static readonly Regex PathStyleS3Endpoint =
+        new Regex("^" + S3EndpointSuffix + "$", RegexOptions.IgnoreCase);
+
+    private S3PresignedUrlAttributor()
+    {
+    }
+
+    internal static PresignedUrlAttribution? Attribute(PresignedAwsUrl presignedAwsUrl)
+    {
+        string host = presignedAwsUrl.GetHost();
+        bool pathStyle = PathStyleS3Endpoint.IsMatch(host);
+
+        string? bucket;
+        if (pathStyle)
+        {
+            bucket = GetPathStyleBucket(presignedAwsUrl);
+        }
+        else
+        {
+            bucket = GetVirtualHostedStyleBucket(host);
+            if (bucket == null)
+            {
+                // Not a recognized S3 endpoint (custom CNAME, access point, unknown host). Fail
+                // closed: the signing service cannot be recovered from a redacted credential scope.
+                return null;
+            }
+        }
+
+        RemoteResource? remoteResource = bucket == null ? null : new RemoteResource(S3BucketResourceType, bucket);
+
+        return new PresignedUrlAttribution(
+            NormalizedS3ServiceName,
+            GetRemoteOperation(presignedAwsUrl, pathStyle),
+            remoteResource);
+    }
+
+    private static string GetRemoteOperation(PresignedAwsUrl presignedAwsUrl, bool pathStyle)
+    {
+        string? httpMethod = presignedAwsUrl.GetHttpMethod();
+        if (httpMethod == null)
+        {
+            return UnknownRemoteOperation;
+        }
+
+        string normalizedMethod = httpMethod.ToUpperInvariant();
+        bool hasObjectKeyPresent = HasObjectKey(presignedAwsUrl, pathStyle);
+
+        // ListObjectsV2 is a bucket-level GET (no object key). Presence of `list-type` is a unique,
+        // unambiguous marker (see class remarks); its value is unavailable after redaction.
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+        if (normalizedMethod == "GET" && !hasObjectKeyPresent && presignedAwsUrl.HasQueryParameter("list-type"))
+        {
+            return "ListObjectsV2";
+        }
+
+        // S3 multipart REST API operations.
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+        if (presignedAwsUrl.HasQueryParameter("uploadId"))
+        {
+            if (normalizedMethod == "PUT" && presignedAwsUrl.HasQueryParameter("partNumber"))
+            {
+                return "UploadPart";
+            }
+
+            if (normalizedMethod == "GET")
+            {
+                return "ListParts";
+            }
+
+            if (normalizedMethod == "POST")
+            {
+                return "CompleteMultipartUpload";
+            }
+
+            if (normalizedMethod == "DELETE")
+            {
+                return "AbortMultipartUpload";
+            }
+        }
+
+        if (presignedAwsUrl.HasQueryParameter("uploads"))
+        {
+            if (normalizedMethod == "POST" && hasObjectKeyPresent)
+            {
+                return "CreateMultipartUpload";
+            }
+
+            if (normalizedMethod == "GET" && !hasObjectKeyPresent)
+            {
+                return "ListMultipartUploads";
+            }
+        }
+
+        // Subresource operations selected by a query parameter. They are object-level when an object
+        // key is present and bucket-level otherwise.
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html
+        if (presignedAwsUrl.HasQueryParameter("acl"))
+        {
+            if (normalizedMethod == "GET")
+            {
+                return hasObjectKeyPresent ? "GetObjectAcl" : "GetBucketAcl";
+            }
+
+            if (normalizedMethod == "PUT")
+            {
+                return hasObjectKeyPresent ? "PutObjectAcl" : "PutBucketAcl";
+            }
+        }
+
+        if (presignedAwsUrl.HasQueryParameter("tagging"))
+        {
+            if (normalizedMethod == "GET")
+            {
+                return hasObjectKeyPresent ? "GetObjectTagging" : "GetBucketTagging";
+            }
+
+            if (normalizedMethod == "PUT")
+            {
+                return hasObjectKeyPresent ? "PutObjectTagging" : "PutBucketTagging";
+            }
+
+            if (normalizedMethod == "DELETE")
+            {
+                return hasObjectKeyPresent ? "DeleteObjectTagging" : "DeleteBucketTagging";
+            }
+        }
+
+        // Object-only subresources. These operate on an object, so they require an object key.
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectRetention.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTorrent.html
+        if (hasObjectKeyPresent)
+        {
+            if (presignedAwsUrl.HasQueryParameter("retention"))
+            {
+                if (normalizedMethod == "GET")
+                {
+                    return "GetObjectRetention";
+                }
+
+                if (normalizedMethod == "PUT")
+                {
+                    return "PutObjectRetention";
+                }
+            }
+
+            if (presignedAwsUrl.HasQueryParameter("legal-hold"))
+            {
+                if (normalizedMethod == "GET")
+                {
+                    return "GetObjectLegalHold";
+                }
+
+                if (normalizedMethod == "PUT")
+                {
+                    return "PutObjectLegalHold";
+                }
+            }
+
+            if (normalizedMethod == "GET" && presignedAwsUrl.HasQueryParameter("torrent"))
+            {
+                return "GetObjectTorrent";
+            }
+        }
+
+        if (!hasObjectKeyPresent)
+        {
+            return UnknownRemoteOperation;
+        }
+
+        switch (normalizedMethod)
+        {
+            case "GET":
+                return "GetObject";
+            case "HEAD":
+                return "HeadObject";
+            case "PUT":
+                return "PutObject";
+            case "DELETE":
+                return "DeleteObject";
+            default:
+                return UnknownRemoteOperation;
+        }
+    }
+
+    private static bool HasObjectKey(PresignedAwsUrl presignedAwsUrl, bool pathStyle)
+    {
+        string[] pathSegments = GetPathSegments(presignedAwsUrl.GetPath());
+        if (pathStyle)
+        {
+            // Path-style URLs carry the bucket as the first path segment, so an object key requires
+            // a second segment.
+            return pathSegments.Length > 1;
+        }
+
+        return pathSegments.Length > 0;
+    }
+
+    private static string? GetPathStyleBucket(PresignedAwsUrl presignedAwsUrl)
+    {
+        string[] pathSegments = GetPathSegments(presignedAwsUrl.GetPath());
+        if (pathSegments.Length == 0)
+        {
+            return null;
+        }
+
+        return pathSegments[0];
+    }
+
+    private static string? GetVirtualHostedStyleBucket(string host)
+    {
+        Match match = VirtualHostedS3Endpoint.Match(host);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return match.Groups[1].Value;
+    }
+
+    private static string[] GetPathSegments(string path)
+    {
+        string normalizedPath = (path ?? string.Empty).TrimStart('/');
+        if (normalizedPath.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        // Drop empty segments so a trailing slash (e.g. path-style "/bucket/") is not misread as an
+        // object key. Java's String.split already discards trailing empties; C#'s String.Split does
+        // not.
+        return normalizedPath.Split('/').Where(segment => segment.Length > 0).ToArray();
+    }
+}

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/S3PresignedUrlAttributor.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/S3PresignedUrlAttributor.cs
@@ -15,18 +15,10 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation;
 /// fails closed (returns null) so we never mis-attribute a non-S3 or unverifiable request.</para>
 ///
 /// <para>The remote operation is derived from the HTTP method, whether an object key is present
-/// (bucket- vs object-level), and the S3 subresource/multipart query parameters. Operation names
-/// follow the S3 REST API.</para>
-///
-/// <para><b>.NET-specific divergence:</b> the Java/Python/JS ports read the <c>list-type</c> value to
-/// confirm it equals <c>2</c> before mapping a bucket-level GET to <c>ListObjectsV2</c>. This distro's
-/// URL sanitization blanks every query value (see PresignedAwsUrlParser remarks), so the value is
-/// unavailable — this port keys on the <b>presence</b> of the <c>list-type</c> parameter instead. That
-/// is safe because <c>list-type</c> is unique to ListObjectsV2 in the S3 REST API (its only defined
-/// value is <c>2</c>, and no other operation uses the parameter), so its presence alone is an
-/// unambiguous marker. All other operation markers are valueless flags (e.g. <c>acl</c>,
-/// <c>tagging</c>, <c>uploads</c>) or presence-only keys (<c>uploadId</c>, <c>partNumber</c>), which
-/// survive sanitization intact.</para>
+/// (bucket- vs object-level), and the presence of S3 subresource/multipart query parameters.
+/// Query values are unavailable (URL sanitization blanks them), so operations are keyed on parameter
+/// presence only. This is unambiguous because each marker parameter selects a single operation family:
+/// e.g. <c>list-type</c> is used only by ListObjectsV2. Operation names follow the S3 REST API.</para>
 ///
 /// <para>References:
 /// <list type="bullet">
@@ -59,10 +51,10 @@ internal sealed class S3PresignedUrlAttributor
         @")?\.amazonaws\.com(?:\.cn)?";
 
     private static readonly Regex VirtualHostedS3Endpoint =
-        new Regex("^(.+)\\." + S3EndpointSuffix + "$", RegexOptions.IgnoreCase);
+        new Regex("^(.+)\\." + S3EndpointSuffix + "$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private static readonly Regex PathStyleS3Endpoint =
-        new Regex("^" + S3EndpointSuffix + "$", RegexOptions.IgnoreCase);
+        new Regex("^" + S3EndpointSuffix + "$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private S3PresignedUrlAttributor()
     {
@@ -108,8 +100,7 @@ internal sealed class S3PresignedUrlAttributor
         string normalizedMethod = httpMethod.ToUpperInvariant();
         bool hasObjectKeyPresent = HasObjectKey(presignedAwsUrl, pathStyle);
 
-        // ListObjectsV2 is a bucket-level GET (no object key). Presence of `list-type` is a unique,
-        // unambiguous marker (see class remarks); its value is unavailable after redaction.
+        // ListObjectsV2 is a bucket-level GET (no object key).
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
         if (normalizedMethod == "GET" && !hasObjectKeyPresent && presignedAwsUrl.HasQueryParameter("list-type"))
         {
@@ -296,8 +287,7 @@ internal sealed class S3PresignedUrlAttributor
         }
 
         // Drop empty segments so a trailing slash (e.g. path-style "/bucket/") is not misread as an
-        // object key. Java's String.split already discards trailing empties; C#'s String.Split does
-        // not.
+        // object key.
         return normalizedPath.Split('/').Where(segment => segment.Length > 0).ToArray();
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedAwsUrlParserTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedAwsUrlParserTest.cs
@@ -8,10 +8,9 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
 
 // Tests for PresignedAwsUrlParser.
 //
-// Detection is presence-only: this distro's URL sanitization blanks every query value to the literal
-// "Redacted" before attribution runs, so the parser cannot read the X-Amz-Algorithm value (nor any
-// other value). The tests use realistic sanitized URLs (redacted credential and signature) to reflect
-// what the parser actually sees at runtime.
+// This distro's URL sanitization blanks every query value to the literal "Redacted" before
+// attribution runs, so the tests use realistic sanitized URLs to reflect what the parser sees at
+// runtime.
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]
 public class PresignedAwsUrlParserTest
 {
@@ -60,9 +59,8 @@ public class PresignedAwsUrlParserTest
     [Fact]
     public void TestAcceptsPresignedRequestRegardlessOfAlgorithmValue()
     {
-        // Presence-only detection: because sanitization blanks the X-Amz-Algorithm value, the parser
-        // must accept the request no matter what value the parameter carries (including "Redacted"
-        // or a non-SigV4 string). This is the key .NET divergence from the value-allowlist ports.
+        // The parser accepts the request regardless of the X-Amz-Algorithm value, since sanitization
+        // blanks it.
         string[] algorithmValues = { "Redacted", "AWS4-HMAC-SHA256", "AWS4-ECDSA-P256-SHA256", "anything" };
         foreach (string algorithm in algorithmValues)
         {
@@ -78,9 +76,7 @@ public class PresignedAwsUrlParserTest
     [Fact]
     public void TestAcceptsValuelessRequiredParameters()
     {
-        // A presigned parameter present with no value (e.g. "X-Amz-Expires" with an empty value)
-        // still counts: presence is the only signal. The value-allowlist ports reject empty values,
-        // but under .NET sanitization values are never trustworthy, so presence alone gates.
+        // A presigned parameter present with an empty value still counts: presence is the only signal.
         string url =
             "https://example-bucket.s3.us-west-2.amazonaws.com/object" +
             "?X-Amz-Algorithm=&X-Amz-Credential=&X-Amz-Signature=&X-Amz-Date=&X-Amz-Expires=&X-Amz-SignedHeaders=";

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedAwsUrlParserTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedAwsUrlParserTest.cs
@@ -15,20 +15,6 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]
 public class PresignedAwsUrlParserTest
 {
-    // A realistic sanitized presigned URL: the agent redacts the credential and signature values
-    // before attribution runs. The non-redacted presigned parameters remain (also redacted here,
-    // matching runtime behavior where every value is blanked).
-    private static string PresignedUrl(string host, string path)
-    {
-        return "https://" + host + path +
-            "?X-Amz-Algorithm=Redacted" +
-            "&X-Amz-Credential=Redacted" +
-            "&X-Amz-Signature=Redacted" +
-            "&X-Amz-Date=Redacted" +
-            "&X-Amz-Expires=Redacted" +
-            "&X-Amz-SignedHeaders=Redacted";
-    }
-
     [Fact]
     public void TestParsesPresignedUrl()
     {
@@ -108,8 +94,23 @@ public class PresignedAwsUrlParserTest
             PresignedAwsUrlParser.Parse(PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", string.Empty), null);
 
         Assert.NotNull(presignedAwsUrl);
+
         // An empty path defaults to "/".
         Assert.Equal("/", presignedAwsUrl!.GetPath());
         Assert.Null(presignedAwsUrl.GetHttpMethod());
+    }
+
+    // A realistic sanitized presigned URL: the agent redacts the credential and signature values
+    // before attribution runs. The non-redacted presigned parameters remain (also redacted here,
+    // matching runtime behavior where every value is blanked).
+    private static string PresignedUrl(string host, string path)
+    {
+        return "https://" + host + path +
+            "?X-Amz-Algorithm=Redacted" +
+            "&X-Amz-Credential=Redacted" +
+            "&X-Amz-Signature=Redacted" +
+            "&X-Amz-Date=Redacted" +
+            "&X-Amz-Expires=Redacted" +
+            "&X-Amz-SignedHeaders=Redacted";
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedAwsUrlParserTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedAwsUrlParserTest.cs
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.AutoInstrumentation;
+using Xunit;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
+
+// Tests for PresignedAwsUrlParser.
+//
+// Detection is presence-only: this distro's URL sanitization blanks every query value to the literal
+// "Redacted" before attribution runs, so the parser cannot read the X-Amz-Algorithm value (nor any
+// other value). The tests use realistic sanitized URLs (redacted credential and signature) to reflect
+// what the parser actually sees at runtime.
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]
+public class PresignedAwsUrlParserTest
+{
+    // A realistic sanitized presigned URL: the agent redacts the credential and signature values
+    // before attribution runs. The non-redacted presigned parameters remain (also redacted here,
+    // matching runtime behavior where every value is blanked).
+    private static string PresignedUrl(string host, string path)
+    {
+        return "https://" + host + path +
+            "?X-Amz-Algorithm=Redacted" +
+            "&X-Amz-Credential=Redacted" +
+            "&X-Amz-Signature=Redacted" +
+            "&X-Amz-Date=Redacted" +
+            "&X-Amz-Expires=Redacted" +
+            "&X-Amz-SignedHeaders=Redacted";
+    }
+
+    [Fact]
+    public void TestParsesPresignedUrl()
+    {
+        PresignedAwsUrl? presignedAwsUrl =
+            PresignedAwsUrlParser.Parse(PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"), "GET");
+
+        Assert.NotNull(presignedAwsUrl);
+        Assert.Equal("example-bucket.s3.us-west-2.amazonaws.com", presignedAwsUrl!.GetHost());
+        Assert.Equal("/object", presignedAwsUrl.GetPath());
+        Assert.Equal("GET", presignedAwsUrl.GetHttpMethod());
+    }
+
+    [Fact]
+    public void TestRejectsUrlsMissingRequiredParameters()
+    {
+        // description -> URL expected to be rejected (returns null).
+        Dictionary<string, string?> cases = new Dictionary<string, string?>
+        {
+            ["null url"] = null,
+            ["empty url"] = string.Empty,
+            ["not a url"] = "not-a-url",
+            ["no query parameters"] = "https://example-bucket.s3.us-west-2.amazonaws.com/object",
+            ["missing X-Amz-Algorithm"] =
+                "https://example-bucket.s3.us-west-2.amazonaws.com/object" +
+                "?X-Amz-Credential=Redacted&X-Amz-Signature=Redacted&X-Amz-Date=Redacted" +
+                "&X-Amz-Expires=Redacted&X-Amz-SignedHeaders=Redacted",
+            ["missing X-Amz-Expires"] =
+                "https://example-bucket.s3.us-west-2.amazonaws.com/object" +
+                "?X-Amz-Algorithm=Redacted&X-Amz-Credential=Redacted&X-Amz-Signature=Redacted" +
+                "&X-Amz-Date=Redacted&X-Amz-SignedHeaders=Redacted",
+            ["missing X-Amz-SignedHeaders"] =
+                "https://example-bucket.s3.us-west-2.amazonaws.com/object" +
+                "?X-Amz-Algorithm=Redacted&X-Amz-Credential=Redacted&X-Amz-Signature=Redacted" +
+                "&X-Amz-Date=Redacted&X-Amz-Expires=Redacted",
+        };
+
+        foreach (KeyValuePair<string, string?> testCase in cases)
+        {
+            Assert.Null(PresignedAwsUrlParser.Parse(testCase.Value, "GET"));
+        }
+    }
+
+    [Fact]
+    public void TestAcceptsPresignedRequestRegardlessOfAlgorithmValue()
+    {
+        // Presence-only detection: because sanitization blanks the X-Amz-Algorithm value, the parser
+        // must accept the request no matter what value the parameter carries (including "Redacted"
+        // or a non-SigV4 string). This is the key .NET divergence from the value-allowlist ports.
+        string[] algorithmValues = { "Redacted", "AWS4-HMAC-SHA256", "AWS4-ECDSA-P256-SHA256", "anything" };
+        foreach (string algorithm in algorithmValues)
+        {
+            string url =
+                "https://example-bucket.s3.us-west-2.amazonaws.com/object" +
+                "?X-Amz-Algorithm=" + algorithm +
+                "&X-Amz-Credential=Redacted&X-Amz-Signature=Redacted&X-Amz-Date=Redacted" +
+                "&X-Amz-Expires=Redacted&X-Amz-SignedHeaders=Redacted";
+            Assert.NotNull(PresignedAwsUrlParser.Parse(url, "GET"));
+        }
+    }
+
+    [Fact]
+    public void TestAcceptsValuelessRequiredParameters()
+    {
+        // A presigned parameter present with no value (e.g. "X-Amz-Expires" with an empty value)
+        // still counts: presence is the only signal. The value-allowlist ports reject empty values,
+        // but under .NET sanitization values are never trustworthy, so presence alone gates.
+        string url =
+            "https://example-bucket.s3.us-west-2.amazonaws.com/object" +
+            "?X-Amz-Algorithm=&X-Amz-Credential=&X-Amz-Signature=&X-Amz-Date=&X-Amz-Expires=&X-Amz-SignedHeaders=";
+        Assert.NotNull(PresignedAwsUrlParser.Parse(url, "GET"));
+    }
+
+    [Fact]
+    public void TestPreservesHttpMethodAndDefaultsPath()
+    {
+        PresignedAwsUrl? presignedAwsUrl =
+            PresignedAwsUrlParser.Parse(PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", string.Empty), null);
+
+        Assert.NotNull(presignedAwsUrl);
+        // An empty path defaults to "/".
+        Assert.Equal("/", presignedAwsUrl!.GetPath());
+        Assert.Null(presignedAwsUrl.GetHttpMethod());
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedUrlMetricAttributeGeneratorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedUrlMetricAttributeGeneratorTest.cs
@@ -47,19 +47,6 @@ public class PresignedUrlMetricAttributeGeneratorTest : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    // A realistic sanitized presigned URL: the agent redacts every query value before attribution
-    // runs, so all six SigV4 parameters carry the literal "Redacted".
-    private static string PresignedUrl(string host, string path)
-    {
-        return "https://" + host + path +
-            "?X-Amz-Algorithm=Redacted" +
-            "&X-Amz-Credential=Redacted" +
-            "&X-Amz-Signature=Redacted" +
-            "&X-Amz-Date=Redacted" +
-            "&X-Amz-Expires=Redacted" +
-            "&X-Amz-SignedHeaders=Redacted";
-    }
-
     [Fact]
     public void TestPresignedS3AttributionDisabledByDefault()
     {
@@ -69,6 +56,7 @@ public class PresignedUrlMetricAttributeGeneratorTest : IDisposable
         span.SetTag(AttributeHttpRequestMethod, "PUT");
 
         ActivityTagsCollection attributes = this.DependencyAttributes(span);
+
         // The generic HTTP fallback derives the remote service from the URL host and appends the
         // port (443 for HTTPS).
         Assert.Equal("example-bucket.s3.us-west-2.amazonaws.com:443", attributes[AttributeAWSRemoteService]);
@@ -169,6 +157,7 @@ public class PresignedUrlMetricAttributeGeneratorTest : IDisposable
         ActivityTagsCollection attributes = this.DependencyAttributes(span);
         Assert.Equal("PeerService", attributes[AttributeAWSRemoteService]);
         Assert.Equal("PutObject", attributes[AttributeAWSRemoteOperation]);
+
         // peer.service overrides the remote service but not the resource, mirroring the SDK path: the
         // S3 bucket resource stays attached even though the service is now the peer value.
         Assert.Equal("AWS::S3::Bucket", attributes[AttributeAWSRemoteResourceType]);
@@ -225,6 +214,7 @@ public class PresignedUrlMetricAttributeGeneratorTest : IDisposable
     {
         Activity? span = this.testSource.StartActivity("presigned", ActivityKind.Client);
         Assert.NotNull(span);
+
         // Non-local-root so the dependency path runs without InternalOperation/LOCAL_ROOT handling.
         span.SetParentId(this.parentSpan.TraceId, this.parentSpan.SpanId);
         return span;
@@ -236,5 +226,18 @@ public class PresignedUrlMetricAttributeGeneratorTest : IDisposable
             this.generator.GenerateMetricAttributeMapFromSpan(span, this.resource);
         Assert.True(attributeMap.TryGetValue(MetricAttributeGeneratorConstants.DependencyMetric, out ActivityTagsCollection? dependencyMetric));
         return dependencyMetric!;
+    }
+
+    // A realistic sanitized presigned URL: the agent redacts every query value before attribution
+    // runs, so all six SigV4 parameters carry the literal "Redacted".
+    private static string PresignedUrl(string host, string path)
+    {
+        return "https://" + host + path +
+            "?X-Amz-Algorithm=Redacted" +
+            "&X-Amz-Credential=Redacted" +
+            "&X-Amz-Signature=Redacted" +
+            "&X-Amz-Date=Redacted" +
+            "&X-Amz-Expires=Redacted" +
+            "&X-Amz-SignedHeaders=Redacted";
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedUrlMetricAttributeGeneratorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/PresignedUrlMetricAttributeGeneratorTest.cs
@@ -1,0 +1,240 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using AWS.Distro.OpenTelemetry.AutoInstrumentation;
+using OpenTelemetry.Resources;
+using Xunit;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsAttributeKeys;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsMetricAttributeGenerator;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsSpanProcessingUtil;
+using static OpenTelemetry.Trace.TraceSemanticConventions;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
+
+// Generator-level wiring tests for presigned AWS URL attribution.
+//
+// These exercise AwsMetricAttributeGenerator end to end (config gating, AWS-SDK exclusion, remote
+// resource reuse, and suppression of the generic HTTP operation fallback), complementing the
+// component tests for the parser and the S3 attributor.
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+public class PresignedUrlMetricAttributeGeneratorTest : IDisposable
+{
+    private const string PresignedUrlAttributionEnabledConfig = "OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED";
+
+    private readonly ActivitySource testSource = new ActivitySource("Test Source");
+    private readonly AwsMetricAttributeGenerator generator = new AwsMetricAttributeGenerator();
+    private readonly Resource resource = Resource.Empty;
+    private readonly Activity? parentSpan;
+
+    public PresignedUrlMetricAttributeGeneratorTest()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = (activitySource) => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+        this.parentSpan = this.testSource.StartActivity("test");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, null);
+        this.parentSpan?.Dispose();
+        this.testSource.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // A realistic sanitized presigned URL: the agent redacts every query value before attribution
+    // runs, so all six SigV4 parameters carry the literal "Redacted".
+    private static string PresignedUrl(string host, string path)
+    {
+        return "https://" + host + path +
+            "?X-Amz-Algorithm=Redacted" +
+            "&X-Amz-Credential=Redacted" +
+            "&X-Amz-Signature=Redacted" +
+            "&X-Amz-Date=Redacted" +
+            "&X-Amz-Expires=Redacted" +
+            "&X-Amz-SignedHeaders=Redacted";
+    }
+
+    [Fact]
+    public void TestPresignedS3AttributionDisabledByDefault()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, null);
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpRequestMethod, "PUT");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        // The generic HTTP fallback derives the remote service from the URL host and appends the
+        // port (443 for HTTPS).
+        Assert.Equal("example-bucket.s3.us-west-2.amazonaws.com:443", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("PUT /object", attributes[AttributeAWSRemoteOperation]);
+        Assert.False(attributes.ContainsKey(AttributeAWSRemoteResourceType));
+        Assert.False(attributes.ContainsKey(AttributeAWSRemoteResourceIdentifier));
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlAttributes()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpRequestMethod, "GET");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("AWS::S3", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("GetObject", attributes[AttributeAWSRemoteOperation]);
+        Assert.Equal("AWS::S3::Bucket", attributes[AttributeAWSRemoteResourceType]);
+        Assert.Equal("example-bucket", attributes[AttributeAWSRemoteResourceIdentifier]);
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlUnknownOperationDoesNotFallBackToHttpPath()
+    {
+        // Bucket-level GET (no object key, no list-type) is ambiguous, so the resolver returns
+        // UnknownRemoteOperation. The generic HTTP operation fallback must not overwrite it with a
+        // high-cardinality "GET /..." value.
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/"));
+        span.SetTag(AttributeHttpRequestMethod, "GET");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("AWS::S3", attributes[AttributeAWSRemoteService]);
+        Assert.Equal(UnknownRemoteOperation, attributes[AttributeAWSRemoteOperation]);
+        Assert.Equal("AWS::S3::Bucket", attributes[AttributeAWSRemoteResourceType]);
+        Assert.Equal("example-bucket", attributes[AttributeAWSRemoteResourceIdentifier]);
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlUsesLegacyHttpUrlFallback()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeHttpUrl, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpMethod, "HEAD");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("AWS::S3", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("HeadObject", attributes[AttributeAWSRemoteOperation]);
+        Assert.Equal("AWS::S3::Bucket", attributes[AttributeAWSRemoteResourceType]);
+        Assert.Equal("example-bucket", attributes[AttributeAWSRemoteResourceIdentifier]);
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlExplicitRemoteAttributesWin()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpRequestMethod, "PUT");
+        span.SetTag(AttributeAWSRemoteService, "AWS remote service");
+        span.SetTag(AttributeAWSRemoteOperation, "AWS remote operation");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("AWS remote service", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("AWS remote operation", attributes[AttributeAWSRemoteOperation]);
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlDoesNotAttributeAwsSdkSpan()
+    {
+        // An AWS SDK span (rpc.system=aws-api) must be excluded from presigned attribution even when
+        // its rpc.service/rpc.method are absent, so it keeps the generic HTTP attribution.
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpRequestMethod, "GET");
+        span.SetTag(AttributeRpcSystem, "aws-api");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("example-bucket.s3.us-west-2.amazonaws.com:443", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("GET /object", attributes[AttributeAWSRemoteOperation]);
+        Assert.False(attributes.ContainsKey(AttributeAWSRemoteResourceType));
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlPeerServiceOverrideIsUnchanged()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpRequestMethod, "PUT");
+        span.SetTag(AttributePeerService, "PeerService");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("PeerService", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("PutObject", attributes[AttributeAWSRemoteOperation]);
+        // peer.service overrides the remote service but not the resource, mirroring the SDK path: the
+        // S3 bucket resource stays attached even though the service is now the peer value.
+        Assert.Equal("AWS::S3::Bucket", attributes[AttributeAWSRemoteResourceType]);
+        Assert.Equal("example-bucket", attributes[AttributeAWSRemoteResourceIdentifier]);
+    }
+
+    [Fact]
+    public void TestNonS3PresignedEndpointIsUnchanged()
+    {
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("sqs.us-west-2.amazonaws.com", "/123456789012/example-queue"));
+        span.SetTag(AttributeHttpRequestMethod, "GET");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("sqs.us-west-2.amazonaws.com:443", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("GET /123456789012", attributes[AttributeAWSRemoteOperation]);
+        Assert.False(attributes.ContainsKey(AttributeAWSRemoteResourceType));
+    }
+
+    [Fact]
+    public void TestPresignedS3UrlWithUnrecognizedEndpointIsUnchanged()
+    {
+        // An access-point host is not a recognized bucket-bearing S3 endpoint. Attribution fails
+        // closed and the span keeps the existing generic HTTP attribution.
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeUrlFull, PresignedUrl("example-bucket.s3-accesspoint.us-west-2.amazonaws.com", "/object"));
+        span.SetTag(AttributeHttpRequestMethod, "GET");
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("example-bucket.s3-accesspoint.us-west-2.amazonaws.com:443", attributes[AttributeAWSRemoteService]);
+        Assert.Equal("GET /object", attributes[AttributeAWSRemoteOperation]);
+        Assert.False(attributes.ContainsKey(AttributeAWSRemoteResourceType));
+    }
+
+    [Fact]
+    public void TestDbResourceAttributionUnaffectedWhenPresignedAttributionEnabled()
+    {
+        // Enabling presigned attribution must not shadow DB resource attribution.
+        Environment.SetEnvironmentVariable(PresignedUrlAttributionEnabledConfig, "true");
+        Activity span = this.CreateClientSpan();
+        span.SetTag(AttributeDbSystem, "mysql");
+        span.SetTag(AttributeDbName, "db_name");
+        span.SetTag(AttributeServerAddress, "abc.com");
+        span.SetTag(AttributeServerPort, 3306);
+
+        ActivityTagsCollection attributes = this.DependencyAttributes(span);
+        Assert.Equal("DB::Connection", attributes[AttributeAWSRemoteResourceType]);
+        Assert.Equal("db_name|abc.com|3306", attributes[AttributeAWSRemoteResourceIdentifier]);
+    }
+
+    private Activity CreateClientSpan()
+    {
+        Activity? span = this.testSource.StartActivity("presigned", ActivityKind.Client);
+        Assert.NotNull(span);
+        // Non-local-root so the dependency path runs without InternalOperation/LOCAL_ROOT handling.
+        span.SetParentId(this.parentSpan.TraceId, this.parentSpan.SpanId);
+        return span;
+    }
+
+    private ActivityTagsCollection DependencyAttributes(Activity span)
+    {
+        Dictionary<string, ActivityTagsCollection> attributeMap =
+            this.generator.GenerateMetricAttributeMapFromSpan(span, this.resource);
+        Assert.True(attributeMap.TryGetValue(MetricAttributeGeneratorConstants.DependencyMetric, out ActivityTagsCollection? dependencyMetric));
+        return dependencyMetric!;
+    }
+}

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/S3PresignedUrlAttributorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/S3PresignedUrlAttributorTest.cs
@@ -3,6 +3,7 @@
 
 using AWS.Distro.OpenTelemetry.AutoInstrumentation;
 using Xunit;
+using static AWS.Distro.OpenTelemetry.AutoInstrumentation.AwsSpanProcessingUtil;
 
 namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
 
@@ -61,9 +62,9 @@ public class S3PresignedUrlAttributorTest
             ("PUT", "/object", string.Empty, "PutObject"),
             ("HEAD", "/object", string.Empty, "HeadObject"),
             ("DELETE", "/object", string.Empty, "DeleteObject"),
-            ("PATCH", "/object", string.Empty, "UnknownRemoteOperation"),
+            ("PATCH", "/object", string.Empty, UnknownRemoteOperation),
 
-            // ListObjectsV2 is bucket-level only. Presence of list-type is the marker (value blanked).
+            // ListObjectsV2 is bucket-level only.
             ("GET", "/", "&list-type=Redacted", "ListObjectsV2"),
             ("GET", "/object", "&list-type=Redacted", "GetObject"),
             ("PUT", "/object", "&list-type=Redacted", "PutObject"),
@@ -78,7 +79,7 @@ public class S3PresignedUrlAttributorTest
             ("GET", "/", "&uploads", "ListMultipartUploads"),
             ("GET", "/object", "&uploads", "GetObject"),
 
-            // ACL / tagging (object- and bucket-level). These are valueless flags.
+            // ACL / tagging (object- and bucket-level)
             ("GET", "/object", "&acl", "GetObjectAcl"),
             ("PUT", "/object", "&acl", "PutObjectAcl"),
             ("GET", "/", "&acl", "GetBucketAcl"),
@@ -116,7 +117,7 @@ public class S3PresignedUrlAttributorTest
 
             // Trailing slash after the bucket is bucket-level, not an object key.
             ("GET", "/example-bucket/", "&list-type=Redacted", "ListObjectsV2"),
-            ("GET", "/example-bucket/", string.Empty, "UnknownRemoteOperation"),
+            ("GET", "/example-bucket/", string.Empty, UnknownRemoteOperation),
             ("GET", "/example-bucket/object", string.Empty, "GetObject"),
             ("DELETE", "/example-bucket/object", string.Empty, "DeleteObject"),
             ("GET", "/example-bucket", "&acl", "GetBucketAcl"),
@@ -162,7 +163,7 @@ public class S3PresignedUrlAttributorTest
             Attribute(PresignedUrl("GET", "example-bucket.s3.us-west-2.amazonaws.com", "/"));
 
         Assert.Equal("AWS::S3", attribution.RemoteService);
-        Assert.Equal("UnknownRemoteOperation", attribution.RemoteOperation);
+        Assert.Equal(UnknownRemoteOperation, attribution.RemoteOperation);
         Assert.NotNull(attribution.RemoteResource);
     }
 
@@ -173,7 +174,7 @@ public class S3PresignedUrlAttributorTest
             Attribute(PresignedUrl(null, "example-bucket.s3.us-west-2.amazonaws.com", "/object"));
 
         Assert.Equal("AWS::S3", attribution.RemoteService);
-        Assert.Equal("UnknownRemoteOperation", attribution.RemoteOperation);
+        Assert.Equal(UnknownRemoteOperation, attribution.RemoteOperation);
     }
 
     [Fact]

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/S3PresignedUrlAttributorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/S3PresignedUrlAttributorTest.cs
@@ -15,28 +15,6 @@ namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]
 public class S3PresignedUrlAttributorTest
 {
-    private static PresignedAwsUrl? PresignedUrl(string? method, string host, string path, string extraQueryParameters = "")
-    {
-        return PresignedAwsUrlParser.Parse(
-            "https://" + host + path +
-            "?X-Amz-Algorithm=Redacted" +
-            "&X-Amz-Credential=Redacted" +
-            "&X-Amz-Signature=Redacted" +
-            "&X-Amz-Date=Redacted" +
-            "&X-Amz-Expires=Redacted" +
-            "&X-Amz-SignedHeaders=Redacted" +
-            extraQueryParameters,
-            method);
-    }
-
-    private static PresignedUrlAttribution Attribute(PresignedAwsUrl? url)
-    {
-        Assert.NotNull(url);
-        PresignedUrlAttribution? attribution = S3PresignedUrlAttributor.Attribute(url!);
-        Assert.NotNull(attribution);
-        return attribution!;
-    }
-
     [Fact]
     public void TestResolvesBucketForEndpointVariant()
     {
@@ -54,6 +32,7 @@ public class S3PresignedUrlAttributorTest
             ("example-bucket.s3-accelerate.dualstack.amazonaws.com", "/object", "example-bucket"),
             ("example-bucket.s3-fips.us-west-2.amazonaws.com", "/object", "example-bucket"),
             ("example-bucket.s3-fips.dualstack.us-east-1.amazonaws.com", "/object", "example-bucket"),
+
             // Path-style: bucket is the first path segment
             ("s3.amazonaws.com", "/example-bucket/object", "example-bucket"),
             ("s3.us-west-2.amazonaws.com", "/example-bucket/object", "example-bucket"),
@@ -83,10 +62,12 @@ public class S3PresignedUrlAttributorTest
             ("HEAD", "/object", string.Empty, "HeadObject"),
             ("DELETE", "/object", string.Empty, "DeleteObject"),
             ("PATCH", "/object", string.Empty, "UnknownRemoteOperation"),
+
             // ListObjectsV2 is bucket-level only. Presence of list-type is the marker (value blanked).
             ("GET", "/", "&list-type=Redacted", "ListObjectsV2"),
             ("GET", "/object", "&list-type=Redacted", "GetObject"),
             ("PUT", "/object", "&list-type=Redacted", "PutObject"),
+
             // Multipart
             ("PUT", "/object", "&partNumber=Redacted&uploadId=Redacted", "UploadPart"),
             ("PUT", "/object", "&uploadId=Redacted", "PutObject"),
@@ -96,6 +77,7 @@ public class S3PresignedUrlAttributorTest
             ("POST", "/object", "&uploads", "CreateMultipartUpload"),
             ("GET", "/", "&uploads", "ListMultipartUploads"),
             ("GET", "/object", "&uploads", "GetObject"),
+
             // ACL / tagging (object- and bucket-level). These are valueless flags.
             ("GET", "/object", "&acl", "GetObjectAcl"),
             ("PUT", "/object", "&acl", "PutObjectAcl"),
@@ -107,6 +89,7 @@ public class S3PresignedUrlAttributorTest
             ("GET", "/", "&tagging", "GetBucketTagging"),
             ("PUT", "/", "&tagging", "PutBucketTagging"),
             ("DELETE", "/", "&tagging", "DeleteBucketTagging"),
+
             // Object-only subresources
             ("GET", "/object", "&retention", "GetObjectRetention"),
             ("PUT", "/object", "&retention", "PutObjectRetention"),
@@ -130,6 +113,7 @@ public class S3PresignedUrlAttributorTest
         (string Method, string Path, string ExtraQuery, string ExpectedOperation)[] cases =
         {
             ("GET", "/example-bucket", "&list-type=Redacted", "ListObjectsV2"),
+
             // Trailing slash after the bucket is bucket-level, not an object key.
             ("GET", "/example-bucket/", "&list-type=Redacted", "ListObjectsV2"),
             ("GET", "/example-bucket/", string.Empty, "UnknownRemoteOperation"),
@@ -155,8 +139,10 @@ public class S3PresignedUrlAttributorTest
         {
             // Access point host (bucket not identifiable from the endpoint form)
             "example-bucket.s3-accesspoint.us-west-2.amazonaws.com",
+
             // Custom CNAME
             "s3.mycompany.com",
+
             // Non-S3 AWS service endpoint
             "sqs.us-west-2.amazonaws.com",
         };
@@ -198,5 +184,27 @@ public class S3PresignedUrlAttributorTest
 
         Assert.Equal("AWS::S3", attribution.RemoteService);
         Assert.Null(attribution.RemoteResource);
+    }
+
+    private static PresignedAwsUrl? PresignedUrl(string? method, string host, string path, string extraQueryParameters = "")
+    {
+        return PresignedAwsUrlParser.Parse(
+            "https://" + host + path +
+            "?X-Amz-Algorithm=Redacted" +
+            "&X-Amz-Credential=Redacted" +
+            "&X-Amz-Signature=Redacted" +
+            "&X-Amz-Date=Redacted" +
+            "&X-Amz-Expires=Redacted" +
+            "&X-Amz-SignedHeaders=Redacted" +
+            extraQueryParameters,
+            method);
+    }
+
+    private static PresignedUrlAttribution Attribute(PresignedAwsUrl? url)
+    {
+        Assert.NotNull(url);
+        PresignedUrlAttribution? attribution = S3PresignedUrlAttributor.Attribute(url!);
+        Assert.NotNull(attribution);
+        return attribution!;
     }
 }

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/S3PresignedUrlAttributorTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/S3PresignedUrlAttributorTest.cs
@@ -1,0 +1,202 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Distro.OpenTelemetry.AutoInstrumentation;
+using Xunit;
+
+namespace AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests;
+
+// Tests for S3PresignedUrlAttributor.
+//
+// S3 attribution is driven purely by the endpoint hostname (the signing service cannot be read from
+// the redacted credential scope). Operation resolution keys on query-parameter PRESENCE only,
+// because this distro's URL sanitization blanks every query value to "Redacted" — so the tests set
+// subresource markers with redacted values, matching runtime.
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]
+public class S3PresignedUrlAttributorTest
+{
+    private static PresignedAwsUrl? PresignedUrl(string? method, string host, string path, string extraQueryParameters = "")
+    {
+        return PresignedAwsUrlParser.Parse(
+            "https://" + host + path +
+            "?X-Amz-Algorithm=Redacted" +
+            "&X-Amz-Credential=Redacted" +
+            "&X-Amz-Signature=Redacted" +
+            "&X-Amz-Date=Redacted" +
+            "&X-Amz-Expires=Redacted" +
+            "&X-Amz-SignedHeaders=Redacted" +
+            extraQueryParameters,
+            method);
+    }
+
+    private static PresignedUrlAttribution Attribute(PresignedAwsUrl? url)
+    {
+        Assert.NotNull(url);
+        PresignedUrlAttribution? attribution = S3PresignedUrlAttributor.Attribute(url!);
+        Assert.NotNull(attribution);
+        return attribution!;
+    }
+
+    [Fact]
+    public void TestResolvesBucketForEndpointVariant()
+    {
+        // host, path, expected bucket
+        (string Host, string Path, string ExpectedBucket)[] cases =
+        {
+            // Virtual-hosted style
+            ("example-bucket.s3.amazonaws.com", "/object", "example-bucket"),
+            ("example-bucket.s3.us-west-2.amazonaws.com", "/object", "example-bucket"),
+            ("example-bucket.s3-us-west-2.amazonaws.com", "/object", "example-bucket"),
+            ("example.s3.bucket.s3.us-west-2.amazonaws.com", "/object", "example.s3.bucket"),
+            ("example-bucket.s3.cn-north-1.amazonaws.com.cn", "/object", "example-bucket"),
+            ("example-bucket.s3.dualstack.us-west-2.amazonaws.com", "/object", "example-bucket"),
+            ("example-bucket.s3-accelerate.amazonaws.com", "/object", "example-bucket"),
+            ("example-bucket.s3-accelerate.dualstack.amazonaws.com", "/object", "example-bucket"),
+            ("example-bucket.s3-fips.us-west-2.amazonaws.com", "/object", "example-bucket"),
+            ("example-bucket.s3-fips.dualstack.us-east-1.amazonaws.com", "/object", "example-bucket"),
+            // Path-style: bucket is the first path segment
+            ("s3.amazonaws.com", "/example-bucket/object", "example-bucket"),
+            ("s3.us-west-2.amazonaws.com", "/example-bucket/object", "example-bucket"),
+            ("s3.cn-north-1.amazonaws.com.cn", "/example-bucket/object", "example-bucket"),
+            ("s3-fips.us-west-2.amazonaws.com", "/example-bucket/object", "example-bucket"),
+            ("s3-fips.dualstack.us-east-1.amazonaws.com", "/example-bucket/object", "example-bucket"),
+        };
+
+        foreach ((string host, string path, string expectedBucket) in cases)
+        {
+            PresignedUrlAttribution attribution = Attribute(PresignedUrl("GET", host, path));
+            Assert.Equal("AWS::S3", attribution.RemoteService);
+            Assert.NotNull(attribution.RemoteResource);
+            Assert.Equal("AWS::S3::Bucket", attribution.RemoteResource!.Type);
+            Assert.Equal(expectedBucket, attribution.RemoteResource.Identifier);
+        }
+    }
+
+    [Fact]
+    public void TestResolvesOperation()
+    {
+        // method, path, extra query params, expected operation
+        (string Method, string Path, string ExtraQuery, string ExpectedOperation)[] cases =
+        {
+            ("GET", "/object", string.Empty, "GetObject"),
+            ("PUT", "/object", string.Empty, "PutObject"),
+            ("HEAD", "/object", string.Empty, "HeadObject"),
+            ("DELETE", "/object", string.Empty, "DeleteObject"),
+            ("PATCH", "/object", string.Empty, "UnknownRemoteOperation"),
+            // ListObjectsV2 is bucket-level only. Presence of list-type is the marker (value blanked).
+            ("GET", "/", "&list-type=Redacted", "ListObjectsV2"),
+            ("GET", "/object", "&list-type=Redacted", "GetObject"),
+            ("PUT", "/object", "&list-type=Redacted", "PutObject"),
+            // Multipart
+            ("PUT", "/object", "&partNumber=Redacted&uploadId=Redacted", "UploadPart"),
+            ("PUT", "/object", "&uploadId=Redacted", "PutObject"),
+            ("GET", "/object", "&uploadId=Redacted", "ListParts"),
+            ("POST", "/object", "&uploadId=Redacted", "CompleteMultipartUpload"),
+            ("DELETE", "/object", "&uploadId=Redacted", "AbortMultipartUpload"),
+            ("POST", "/object", "&uploads", "CreateMultipartUpload"),
+            ("GET", "/", "&uploads", "ListMultipartUploads"),
+            ("GET", "/object", "&uploads", "GetObject"),
+            // ACL / tagging (object- and bucket-level). These are valueless flags.
+            ("GET", "/object", "&acl", "GetObjectAcl"),
+            ("PUT", "/object", "&acl", "PutObjectAcl"),
+            ("GET", "/", "&acl", "GetBucketAcl"),
+            ("PUT", "/", "&acl", "PutBucketAcl"),
+            ("GET", "/object", "&tagging", "GetObjectTagging"),
+            ("PUT", "/object", "&tagging", "PutObjectTagging"),
+            ("DELETE", "/object", "&tagging", "DeleteObjectTagging"),
+            ("GET", "/", "&tagging", "GetBucketTagging"),
+            ("PUT", "/", "&tagging", "PutBucketTagging"),
+            ("DELETE", "/", "&tagging", "DeleteBucketTagging"),
+            // Object-only subresources
+            ("GET", "/object", "&retention", "GetObjectRetention"),
+            ("PUT", "/object", "&retention", "PutObjectRetention"),
+            ("GET", "/object", "&legal-hold", "GetObjectLegalHold"),
+            ("PUT", "/object", "&legal-hold", "PutObjectLegalHold"),
+            ("GET", "/object", "&torrent", "GetObjectTorrent"),
+        };
+
+        foreach ((string method, string path, string extraQuery, string expectedOperation) in cases)
+        {
+            PresignedUrlAttribution attribution =
+                Attribute(PresignedUrl(method, "example-bucket.s3.us-west-2.amazonaws.com", path, extraQuery));
+            Assert.Equal(expectedOperation, attribution.RemoteOperation);
+        }
+    }
+
+    [Fact]
+    public void TestResolvesPathStyleOperation()
+    {
+        // method, path, extra query params, expected operation
+        (string Method, string Path, string ExtraQuery, string ExpectedOperation)[] cases =
+        {
+            ("GET", "/example-bucket", "&list-type=Redacted", "ListObjectsV2"),
+            // Trailing slash after the bucket is bucket-level, not an object key.
+            ("GET", "/example-bucket/", "&list-type=Redacted", "ListObjectsV2"),
+            ("GET", "/example-bucket/", string.Empty, "UnknownRemoteOperation"),
+            ("GET", "/example-bucket/object", string.Empty, "GetObject"),
+            ("DELETE", "/example-bucket/object", string.Empty, "DeleteObject"),
+            ("GET", "/example-bucket", "&acl", "GetBucketAcl"),
+            ("GET", "/example-bucket/", "&acl", "GetBucketAcl"),
+            ("GET", "/example-bucket/object", "&acl", "GetObjectAcl"),
+        };
+
+        foreach ((string method, string path, string extraQuery, string expectedOperation) in cases)
+        {
+            PresignedUrlAttribution attribution =
+                Attribute(PresignedUrl(method, "s3.us-west-2.amazonaws.com", path, extraQuery));
+            Assert.Equal(expectedOperation, attribution.RemoteOperation);
+        }
+    }
+
+    [Fact]
+    public void TestFailsClosedForUnrecognizedEndpoint()
+    {
+        string[] hosts =
+        {
+            // Access point host (bucket not identifiable from the endpoint form)
+            "example-bucket.s3-accesspoint.us-west-2.amazonaws.com",
+            // Custom CNAME
+            "s3.mycompany.com",
+            // Non-S3 AWS service endpoint
+            "sqs.us-west-2.amazonaws.com",
+        };
+
+        foreach (string host in hosts)
+        {
+            PresignedAwsUrl? url = PresignedUrl("GET", host, "/object");
+            Assert.NotNull(url);
+            Assert.Null(S3PresignedUrlAttributor.Attribute(url!));
+        }
+    }
+
+    [Fact]
+    public void TestUsesUnknownOperationForAmbiguousBucketOperation()
+    {
+        PresignedUrlAttribution attribution =
+            Attribute(PresignedUrl("GET", "example-bucket.s3.us-west-2.amazonaws.com", "/"));
+
+        Assert.Equal("AWS::S3", attribution.RemoteService);
+        Assert.Equal("UnknownRemoteOperation", attribution.RemoteOperation);
+        Assert.NotNull(attribution.RemoteResource);
+    }
+
+    [Fact]
+    public void TestMissingHttpMethodUsesUnknownOperation()
+    {
+        PresignedUrlAttribution attribution =
+            Attribute(PresignedUrl(null, "example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+
+        Assert.Equal("AWS::S3", attribution.RemoteService);
+        Assert.Equal("UnknownRemoteOperation", attribution.RemoteOperation);
+    }
+
+    [Fact]
+    public void TestPathStyleWithoutBucketAttributesS3WithoutResource()
+    {
+        PresignedUrlAttribution attribution =
+            Attribute(PresignedUrl("GET", "s3.us-west-2.amazonaws.com", "/"));
+
+        Assert.Equal("AWS::S3", attribution.RemoteService);
+        Assert.Null(attribution.RemoteResource);
+    }
+}


### PR DESCRIPTION
## Description

Attributes raw-HTTP **presigned S3 URL** calls as `AWS::S3` dependencies in Application Signals, instead of generic HTTP calls to the bucket host. This fixes the high-cardinality `<METHOD> /<object-key>` remote operation and mis-attributed remote service that presigned S3 requests otherwise produce (they bypass the AWS SDK instrumentation).

Opt-in, default off, via `OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED`.

Ports [aws-observability/aws-otel-java-instrumentation#1423](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1423) to .NET, following the same class boundaries as the Python (#841) and JS (#515) ports:
- `PresignedAwsUrl` — parsed value object (host, path, method, query params)
- `PresignedAwsUrlParser` — SigV4 presigned detection from the six `X-Amz-*` query parameters
- `PresignedUrlAttributor` — dispatcher + result types (`PresignedUrlAttribution`, `RemoteResource`)
- `S3PresignedUrlAttributor` — S3 endpoint hostname recognition + operation mapping
- `AwsMetricAttributeGenerator` — wired as the last remote-service fallback for non-AWS-SDK spans, suppressing the generic HTTP operation fallback when a presigned URL is attributed

## .NET-specific divergence (presence-only detection)

The Java/Python/JS ports read the `X-Amz-Algorithm` value against a SigV4 allowlist and check `list-type=2`. This distro's URL sanitization (`OpenTelemetry.Internal.RedactionHelper.GetRedactedQueryString`) blanks **every** query value to the literal `Redacted` before metric attribution runs, so **no query value is readable**. Detection and operation resolution therefore key on parameter **presence** only:

- The six SigV4 parameter keys co-occurring (anchored by `X-Amz-Expires`, which is presigned-specific) is a high-specificity fingerprint. Dropping the algorithm allowlist is safe because nothing downstream branches on SigV4 vs SigV4a — the service is derived from the hostname.
- **ListObjectsV2 is retained**, not lost: `list-type` is unique to ListObjectsV2 in the S3 REST API (its only defined value is `2`, and no other operation uses the parameter), so its presence alone on a bucket-level GET is an unambiguous marker.
- All other operation markers are valueless flags (`acl`, `tagging`, `uploads`, `torrent`, …) or presence-only keys (`uploadId`, `partNumber`), which survive sanitization intact.

## Testing

- `PresignedAwsUrlParserTest` (5), `S3PresignedUrlAttributorTest` (7), `PresignedUrlMetricAttributeGeneratorTest` (10) — all pass.
- Existing `AwsMetricAttributesGeneratorTest` (30) still pass — no regressions.

## Attribution parity note

Presigned S3 dependencies carry all core S3 metric dimensions — `aws.remote.service` (`AWS::S3`), `aws.remote.operation`, `aws.remote.resource.type`/`identifier`, and the CloudFormation primary identifier — so they land on the same Application Signals dependency node and operation as a regular AWS-SDK S3 call. They do **not** carry the cross-account dimensions `aws.remote.resource.account.access_key` and `aws.remote.resource.region`, which are derived from the SDK-only `aws.auth.*` attributes; those are absent on a presigned request because the credential is redacted. This matches the Java implementation, which gates the same cross-account setters on SDK-only attributes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.