### PR TITLE
fix: apply OTEL_AWS_HTTP_OPERATION_PATHS to aws.local.operation for ASP.NET Core spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   `OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED`
   ([#440](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/440))
 
+- Apply OTEL_AWS_HTTP_OPERATION_PATHS to aws.local.operation for ASP.NET Core spans
+  ([#441](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/441))
+
 - Add adaptive sampling support for anomaly detection and trace capture
   ([#410](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/410))
 

--- a/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
+++ b/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AwsSpanProcessingUtil.cs
@@ -148,57 +148,15 @@ internal sealed class AwsSpanProcessingUtil
     }
 
     /// <summary>
-    /// If OTEL_AWS_HTTP_OPERATION_PATHS is configured and a pattern matches the span's URL path,
-    /// mutates the span's DisplayName to "METHOD /path/template". Returns the span unchanged if
-    /// no config is set or no pattern matches.
+    /// If OTEL_AWS_HTTP_OPERATION_PATHS matches the span's URL path, sets DisplayName to the
+    /// configured operation name so the exported trace carries it. Returns the span unchanged otherwise.
     /// </summary>
     internal static Activity ApplyOperationPathSpanName(Activity span)
     {
-        var paths = GetOperationPaths();
-        if (paths.Count == 0)
+        string? overriddenName = GetOperationPathOverride(span);
+        if (overriddenName != null)
         {
-            return span;
-        }
-
-        string? urlPath = GetUrlPath(span);
-        if (string.IsNullOrEmpty(urlPath))
-        {
-            return span;
-        }
-
-        // Strip query string and fragment (relevant for http.target)
-        string path = urlPath!;
-        foreach (char sep in new[] { '?', '#' })
-        {
-            int idx = path.IndexOf(sep);
-            if (idx >= 0)
-            {
-                path = path.Substring(0, idx);
-            }
-        }
-
-        // Normalize trailing slashes
-        while (path.EndsWith("/") && path.Length > 1)
-        {
-            path = path.Substring(0, path.Length - 1);
-        }
-
-        string[] urlSegments = path.Split('/');
-        foreach (string pattern in paths)
-        {
-            string normalizedPattern = pattern;
-            while (normalizedPattern.EndsWith("/") && normalizedPattern.Length > 1)
-            {
-                normalizedPattern = normalizedPattern.Substring(0, normalizedPattern.Length - 1);
-            }
-
-            if (SegmentsMatch(urlSegments, normalizedPattern.Split('/')))
-            {
-                string? httpMethod = GetHttpMethod(span);
-                string newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
-                span.DisplayName = newName;
-                return span;
-            }
+            span.DisplayName = overriddenName;
         }
 
         return span;
@@ -214,14 +172,22 @@ internal sealed class AwsSpanProcessingUtil
             return InternalOperation;
         }
 
+        // A configured operation path takes precedence over the ASP.NET Core route template.
+        string? operationPathOverride = GetOperationPathOverride(span);
+        if (operationPathOverride != null)
+        {
+            return operationPathOverride;
+        }
+
         // this takes precedence over the FunctionHandler path. Basically, if HttpContextWeakRef exists,
         // this means the the span is coming from ASP.NET Core instrumentation and we want the
         // operation name to be the API Route
-        else if (span.GetCustomProperty("HttpContextWeakRef") != null)
+        if (span.GetCustomProperty("HttpContextWeakRef") != null)
         {
             return GetRouteTemplate(span);
         }
-        else if (IsLambdaEnvironment())
+
+        if (IsLambdaEnvironment())
         {
             return AwsLambdaFunctionName + "/FunctionHandler";
         }
@@ -413,6 +379,60 @@ internal sealed class AwsSpanProcessingUtil
     private static string? GetHttpMethod(Activity span)
     {
         return (string?)span.GetTagItem(AttributeHttpRequestMethod) ?? (string?)span.GetTagItem(AttributeHttpMethod);
+    }
+
+    /// <summary>
+    /// If OTEL_AWS_HTTP_OPERATION_PATHS matches the span's URL path, returns the resolved operation
+    /// name ("METHOD /path/template"). Returns null if no config is set or no pattern matches.
+    /// </summary>
+    private static string? GetOperationPathOverride(Activity span)
+    {
+        var paths = GetOperationPaths();
+        if (paths.Count == 0)
+        {
+            return null;
+        }
+
+        string? urlPath = GetUrlPath(span);
+        if (string.IsNullOrEmpty(urlPath))
+        {
+            return null;
+        }
+
+        // Strip query string and fragment
+        string path = urlPath!;
+        foreach (char sep in new[] { '?', '#' })
+        {
+            int idx = path.IndexOf(sep);
+            if (idx >= 0)
+            {
+                path = path.Substring(0, idx);
+            }
+        }
+
+        // Normalize trailing slashes
+        while (path.EndsWith("/") && path.Length > 1)
+        {
+            path = path.Substring(0, path.Length - 1);
+        }
+
+        string[] urlSegments = path.Split('/');
+        foreach (string pattern in paths)
+        {
+            string normalizedPattern = pattern;
+            while (normalizedPattern.EndsWith("/") && normalizedPattern.Length > 1)
+            {
+                normalizedPattern = normalizedPattern.Substring(0, normalizedPattern.Length - 1);
+            }
+
+            if (SegmentsMatch(urlSegments, normalizedPattern.Split('/')))
+            {
+                string? httpMethod = GetHttpMethod(span);
+                return httpMethod != null ? httpMethod + " " + pattern : pattern;
+            }
+        }
+
+        return null;
     }
 
     private static bool SegmentsMatch(string[] urlSegments, string[] patternSegments)

--- a/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsSpanProcessingUtilTest.cs
+++ b/test/AWS.Distro.OpenTelemetry.AutoInstrumentation.Tests/AwsSpanProcessingUtilTest.cs
@@ -755,4 +755,47 @@ public class AwsSpanProcessingUtilTest
             AwsSpanProcessingUtil.ResetOperationPaths();
         }
     }
+
+#if !NETFRAMEWORK
+    [Fact]
+    public void TestGetIngressOperationPathOverrideTakesPrecedenceOverRouteTemplate()
+    {
+        // The configured path must win over the framework route template. Use distinct values so
+        // the assertion fails if the route template is used instead of the configured path.
+        Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, "/api/contests/{contestId}");
+        AwsSpanProcessingUtil.ResetOperationPaths();
+        try
+        {
+            var contextMock = new Mock<HttpContext>();
+            var featuresMock = new Mock<IFeatureCollection>();
+            var exceptionHandlerFeatureMock = new Mock<IExceptionHandlerPathFeature>();
+
+            var routePattern = RoutePatternFactory.Parse("/api/contests/{id}");
+            var routeEndpoint = new RouteEndpoint(
+                requestDelegate: (context) => Task.CompletedTask,
+                routePattern: routePattern,
+                order: 0,
+                metadata: new EndpointMetadataCollection(),
+                displayName: "RouteTemplateTest");
+
+            exceptionHandlerFeatureMock.Setup(f => f.Endpoint).Returns(routeEndpoint);
+            featuresMock.Setup(f => f.Get<IExceptionHandlerPathFeature>()).Returns(exceptionHandlerFeatureMock.Object);
+            contextMock.Setup(c => c.Features).Returns(featuresMock.Object);
+
+            using var span = this.testSource.StartActivity("GET", ActivityKind.Server);
+            span!.SetTag(AttributeUrlPath, "/api/contests/42");
+            span.SetTag(AttributeHttpRequestMethod, "GET");
+            span.SetCustomProperty("HttpContextWeakRef", new WeakReference<HttpContext>(contextMock.Object));
+            span.Start();
+
+            string actualOperation = GetIngressOperation(span);
+            Assert.Equal("GET /api/contests/{contestId}", actualOperation);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OtelAwsHttpOperationPathsConfig, null);
+            AwsSpanProcessingUtil.ResetOperationPaths();
+        }
+    }
+#endif
 }


### PR DESCRIPTION
## Description

For ASP.NET Core server spans, `GetIngressOperation` always took the `HttpContextWeakRef` branch and derived the operation from the framework route template, overwriting the `DisplayName` that `ApplyOperationPathSpanName` set from `OTEL_AWS_HTTP_OPERATION_PATHS`. As a result the configuration had **no effect** on `aws.local.operation` in .NET, unlike Java ([#1352](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1352)) and Python ([#718](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/718)).

This resolves the configured operation path in `GetIngressOperation` **before** the route-template branch, so a configured path takes precedence, matching the other languages. `ApplyOperationPathSpanName` now shares the same matching logic via `GetOperationPathOverride`.

## Testing

Added a unit test verifying the configured path wins over the ASP.NET Core route template when `HttpContextWeakRef` is present. Full suite passes on net8.0 and net10.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.